### PR TITLE
fix: allow shorthand `RRule.parse` without options

### DIFF
--- a/lib/rrule.rb
+++ b/lib/rrule.rb
@@ -20,8 +20,8 @@ module RRule
   autoload :AllOccurrences, 'rrule/generators/all_occurrences'
   autoload :BySetPosition, 'rrule/generators/by_set_position'
 
-  def self.parse(rrule, options)
-    Rule.new(rrule, options)
+  def self.parse(rrule, **options)
+    Rule.new(rrule, **options)
   end
 
   MAX_YEAR = 9999


### PR DESCRIPTION
Since `RRule::Rule.new` takes keyword arguments for the options, we should accept keyword arguments here and pass them through.

Closes #1