### PR TITLE
Add the option to pass a limit to queries on RRULEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,14 @@ rrule.between(Time.new(2016, 6, 23), Time.new(2016, 6, 24))
 => [2016-06-23 16:45:32 -0700]
 ```
 
+You can limit the number of instances that are returned with the `limit` option:
+
+```ruby
+rrule = RRule::Rule.new('FREQ=DAILY;COUNT=3')
+rrule.all(limit: 2)
+=> [2016-06-23 16:45:32 -0700, 2016-06-24 16:45:32 -0700]
+```
+
 By default the DTSTART of the recurrence is the current time, but this can be overriden with the `dtstart` option:
 
 ```ruby

--- a/lib/rrule/rule.rb
+++ b/lib/rrule/rule.rb
@@ -13,17 +13,17 @@ module RRule
       @options = parse_options
     end
 
-    def all
-      reject_exdates(all_until(nil))
+    def all(limit: nil)
+      reject_exdates(all_until(limit: limit))
     end
 
-    def between(start_date, end_date)
+    def between(start_date, end_date, limit: nil)
       # This removes all sub-second and floors it to the second level.
       # Sub-second level calculations breaks a lot of assumptions in this
       # library and rounding it may also cause unexpected inequalities.
       floored_start_date = Time.at(start_date.to_i)
       floored_end_date = Time.at(end_date.to_i)
-      reject_exdates(all_until(floored_end_date).reject { |instance| instance < floored_start_date })
+      reject_exdates(all_until(end_date: floored_end_date, limit: limit).reject { |instance| instance < floored_start_date })
     end
 
     private
@@ -34,7 +34,7 @@ module RRule
       results.reject { |date| exdate.include?(date) }
     end
 
-    def all_until(end_date)
+    def all_until(end_date: nil, limit: nil)
       result = []
 
       context = Context.new(options, dtstart, tz)
@@ -115,6 +115,8 @@ module RRule
               result.push(this_result)
             end
           end
+
+          return result if limit && result.size == limit
         end
 
         frequency.advance

--- a/spec/rule_spec.rb
+++ b/spec/rule_spec.rb
@@ -22,6 +22,21 @@ describe RRule::Rule do
       ])
     end
 
+    it 'returns the correct result with an rrule of FREQ=DAILY;COUNT=10 and a limit' do
+      rrule = 'FREQ=DAILY;COUNT=10'
+      dtstart = Time.parse('Tue Sep  2 06:00:00 PDT 1997')
+      timezone = 'America/New_York'
+
+      rrule = RRule::Rule.new(rrule, dtstart: dtstart, tzid: timezone)
+      expect(rrule.all(limit: 5)).to match_array([
+        Time.parse('Tue Sep  2 06:00:00 PDT 1997'),
+        Time.parse('Wed Sep  3 06:00:00 PDT 1997'),
+        Time.parse('Thu Sep  4 06:00:00 PDT 1997'),
+        Time.parse('Fri Sep  5 06:00:00 PDT 1997'),
+        Time.parse('Sat Sep  6 06:00:00 PDT 1997')
+      ])
+    end
+
     it 'returns the correct result with an rrule of FREQ=DAILY;UNTIL=19971224T000000Z' do
       rrule = 'FREQ=DAILY;UNTIL=19971224T000000Z'
       dtstart = Time.parse('Tue Sep  2 06:00:00 PDT 1997')
@@ -1704,6 +1719,21 @@ describe RRule::Rule do
         Time.parse('Sat Oct 18 06:00:00 PDT 1997'),
         Time.parse('Mon Oct 20 06:00:00 PDT 1997'),
         Time.parse('Wed Oct 22 06:00:00 PDT 1997')
+      ])
+    end
+
+    it 'returns the correct result with an rrule of FREQ=DAILY;INTERVAL=2 and a limit' do
+      rrule = 'FREQ=DAILY;INTERVAL=2'
+      dtstart = Time.parse('Tue Sep  2 06:00:00 PDT 1997')
+      timezone = 'America/New_York'
+
+      rrule = RRule::Rule.new(rrule, dtstart: dtstart, tzid: timezone)
+      expect(rrule.between(Time.parse('Tue Sep  2 06:00:00 PDT 1997'), Time.parse('Wed Oct 22 06:00:00 PDT 1997'), limit: 5)).to match_array([
+        Time.parse('Tue Sep  2 06:00:00 PDT 1997'),
+        Time.parse('Thu Sep  4 06:00:00 PDT 1997'),
+        Time.parse('Sat Sep  6 06:00:00 PDT 1997'),
+        Time.parse('Mon Sep  8 06:00:00 PDT 1997'),
+        Time.parse('Wed Sep 10 06:00:00 PDT 1997')
       ])
     end
 


### PR DESCRIPTION
One possible use case would be paginating repeats - and at any rate this seems like a pretty natural addition to the `between` operation.