### PR TITLE
Optimize simple weekly case

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ rrule.all
 
 ## License
 
-Copyright 2015 Square Inc.
+Copyright 2018 Square Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/lib/rrule.rb
+++ b/lib/rrule.rb
@@ -8,6 +8,7 @@ module RRule
   autoload :Frequency, 'rrule/frequencies/frequency'
   autoload :Daily, 'rrule/frequencies/daily'
   autoload :Weekly, 'rrule/frequencies/weekly'
+  autoload :SimpleWeekly, 'rrule/frequencies/simple_weekly'
   autoload :Monthly, 'rrule/frequencies/monthly'
   autoload :Yearly, 'rrule/frequencies/yearly'
 

--- a/lib/rrule/frequencies/frequency.rb
+++ b/lib/rrule/frequencies/frequency.rb
@@ -42,7 +42,7 @@ module RRule
         Daily
       when 'WEEKLY'
         if options[:simple_weekly] && !options[:bymonth]
-          SimpleWeekly
+          SimpleWeekly # simplified and faster version if we don't need to deal with filtering
         else
           Weekly
         end

--- a/lib/rrule/frequencies/frequency.rb
+++ b/lib/rrule/frequencies/frequency.rb
@@ -1,10 +1,13 @@
 module RRule
   class Frequency
-    attr_reader :current_date
+    attr_reader :current_date, :filters, :generator, :timeset
 
-    def initialize(context)
+    def initialize(context, filters, generator, timeset)
       @context = context
       @current_date = context.dtstart
+      @filters = filters
+      @generator = generator
+      @timeset = timeset
     end
 
     def advance
@@ -15,8 +18,39 @@ module RRule
       end
     end
 
+    def next_occurrences
+      possible_days_of_year = possible_days
+
+      if filters.present?
+        possible_days_of_year.each_with_index do |day_index, i|
+          possible_days_of_year[i] = nil if filters.any? { |filter| filter.reject?(day_index) }
+        end
+      end
+
+      generator.combine_dates_and_times(possible_days_of_year, timeset).tap do
+        advance
+      end
+    end
+
     def possible_days
       fail NotImplementedError
+    end
+
+    def self.for_options(options)
+      case options[:freq]
+      when 'DAILY'
+        Daily
+      when 'WEEKLY'
+        if options[:simple_weekly] && !options[:bymonth]
+          SimpleWeekly
+        else
+          Weekly
+        end
+      when 'MONTHLY'
+        Monthly
+      when 'YEARLY'
+        Yearly
+      end
     end
 
     private

--- a/lib/rrule/frequencies/simple_weekly.rb
+++ b/lib/rrule/frequencies/simple_weekly.rb
@@ -1,0 +1,9 @@
+module RRule
+  class SimpleWeekly < Frequency
+    def next_occurrences
+      this_occurrence = current_date
+      @current_date += context.options[:interval].weeks
+      [this_occurrence]
+    end
+  end
+end

--- a/rrule.gemspec
+++ b/rrule.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name = 'rrule'
-  s.version = '0.2.1'
-  s.date = '2016-06-06'
+  s.version = '0.3.0'
+  s.date = '2018-04-23'
   s.summary = 'RRule expansion'
   s.description = 'A gem for expanding dates according to the RRule specification'
   s.authors = ['Ryan Mitchell']

--- a/scripts/benchmark.rb
+++ b/scripts/benchmark.rb
@@ -1,0 +1,17 @@
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '../lib/'))
+require 'rrule'
+include Benchmark
+
+rules_to_benchmark = ['FREQ=WEEKLY', 'FREQ=WEEKLY;BYDAY=WE']
+rrule_version = '0.3.0'
+
+puts "Benchmarking rules in version #{rrule_version}\n"
+Benchmark.benchmark(CAPTION, rules_to_benchmark.map(&:size).max, FORMAT) do |bm|
+  rules_to_benchmark.each do |rule|
+    rrule = RRule.parse(rule, dtstart: Time.parse('Wed Jan 30 09:00:00 PST 2013'), tzid: 'America/Chicago')
+    bm.report(rule) do
+      1000.times { rrule.between(Time.parse('Sun Jul 31 22:00:00 PDT 2016'), Time.parse('Wed Aug 31 21:59:59 PDT 2016')) }
+    end
+  end
+end
+puts "\n"

--- a/scripts/benchmark.rb
+++ b/scripts/benchmark.rb
@@ -5,7 +5,7 @@ include Benchmark
 rules_to_benchmark = ['FREQ=WEEKLY', 'FREQ=WEEKLY;BYDAY=WE']
 rrule_version = '0.3.0'
 
-puts "Benchmarking rules in version #{rrule_version}\n"
+puts "Benchmarking rules in version #{rrule_version}: 1000 expansions over one month\n"
 Benchmark.benchmark(CAPTION, rules_to_benchmark.map(&:size).max, FORMAT) do |bm|
   rules_to_benchmark.each do |rule|
     rrule = RRule.parse(rule, dtstart: Time.parse('Wed Jan 30 09:00:00 PST 2013'), tzid: 'America/Chicago')

--- a/scripts/history.txt
+++ b/scripts/history.txt
@@ -1,0 +1,5 @@
+Benchmarking rules in version 0.3.0
+                           user     system      total        real
+FREQ=WEEKLY            7.190000   0.040000   7.230000 (  7.242336)
+FREQ=WEEKLY;BYDAY=WE  12.770000   0.070000  12.840000 ( 12.857210)
+

--- a/spec/frequencies/daily_spec.rb
+++ b/spec/frequencies/daily_spec.rb
@@ -6,7 +6,7 @@ describe RRule::Daily do
     RRule::Context.new(
         { interval: interval },
         date,
-        'UTC'
+        'America/Los_Angeles'
     )
   end
   let(:filters) { [] }
@@ -19,43 +19,43 @@ describe RRule::Daily do
     subject(:frequency) { described_class.new(context, filters, generator, timeset) }
 
     context 'with an interval of one' do
-      let(:date) { Time.utc(1997, 1, 1) }
+      let(:date) { Time.zone.local(1997, 1, 1) }
 
       it 'returns sequential days' do
-        expect(frequency.next_occurrences).to eql [Time.utc(1997, 1, 1)]
-        expect(frequency.next_occurrences).to eql [Time.utc(1997, 1, 2)]
-        expect(frequency.next_occurrences).to eql [Time.utc(1997, 1, 3)]
+        expect(frequency.next_occurrences).to eql [Time.zone.local(1997, 1, 1)]
+        expect(frequency.next_occurrences).to eql [Time.zone.local(1997, 1, 2)]
+        expect(frequency.next_occurrences).to eql [Time.zone.local(1997, 1, 3)]
       end
     end
 
     context 'with an interval of two' do
       let(:interval) { 2 }
-      let(:date) { Time.utc(1997, 1, 1) }
+      let(:date) { Time.zone.local(1997, 1, 1) }
 
       it 'returns every other day' do
-        expect(frequency.next_occurrences).to eql [Time.utc(1997, 1, 1)]
-        expect(frequency.next_occurrences).to eql [Time.utc(1997, 1, 3)]
-        expect(frequency.next_occurrences).to eql [Time.utc(1997, 1, 5)]
+        expect(frequency.next_occurrences).to eql [Time.zone.local(1997, 1, 1)]
+        expect(frequency.next_occurrences).to eql [Time.zone.local(1997, 1, 3)]
+        expect(frequency.next_occurrences).to eql [Time.zone.local(1997, 1, 5)]
       end
     end
 
     context 'on the last day of February' do
-      let(:date) { Time.utc(1997, 2, 28) }
+      let(:date) { Time.zone.local(1997, 2, 28) }
 
       it 'goes into the next month' do
-        expect(frequency.next_occurrences).to eql [Time.utc(1997, 2, 28)]
-        expect(frequency.next_occurrences).to eql [Time.utc(1997, 3, 1)]
-        expect(frequency.next_occurrences).to eql [Time.utc(1997, 3, 2)]
+        expect(frequency.next_occurrences).to eql [Time.zone.local(1997, 2, 28)]
+        expect(frequency.next_occurrences).to eql [Time.zone.local(1997, 3, 1)]
+        expect(frequency.next_occurrences).to eql [Time.zone.local(1997, 3, 2)]
       end
     end
 
     context 'on the last day of the year' do
-      let(:date) { Time.utc(1997, 12, 31) }
+      let(:date) { Time.zone.local(1997, 12, 31) }
 
       it 'goes into the next year' do
-        expect(frequency.next_occurrences).to eql [Time.utc(1997, 12, 31)]
-        expect(frequency.next_occurrences).to eql [Time.utc(1998, 1, 1)]
-        expect(frequency.next_occurrences).to eql [Time.utc(1998, 1, 2)]
+        expect(frequency.next_occurrences).to eql [Time.zone.local(1997, 12, 31)]
+        expect(frequency.next_occurrences).to eql [Time.zone.local(1998, 1, 1)]
+        expect(frequency.next_occurrences).to eql [Time.zone.local(1998, 1, 2)]
       end
     end
   end

--- a/spec/frequencies/daily_spec.rb
+++ b/spec/frequencies/daily_spec.rb
@@ -6,7 +6,7 @@ describe RRule::Daily do
     RRule::Context.new(
         { interval: interval },
         date,
-        'America/Los_Angeles'
+        'UTC'
     )
   end
   let(:filters) { [] }
@@ -19,43 +19,43 @@ describe RRule::Daily do
     subject(:frequency) { described_class.new(context, filters, generator, timeset) }
 
     context 'with an interval of one' do
-      let(:date) { Time.new(1997, 1, 1) }
+      let(:date) { Time.utc(1997, 1, 1) }
 
       it 'returns sequential days' do
-        expect(frequency.next_occurrences).to eql [Time.new(1997, 1, 1)]
-        expect(frequency.next_occurrences).to eql [Time.new(1997, 1, 2)]
-        expect(frequency.next_occurrences).to eql [Time.new(1997, 1, 3)]
+        expect(frequency.next_occurrences).to eql [Time.utc(1997, 1, 1)]
+        expect(frequency.next_occurrences).to eql [Time.utc(1997, 1, 2)]
+        expect(frequency.next_occurrences).to eql [Time.utc(1997, 1, 3)]
       end
     end
 
     context 'with an interval of two' do
       let(:interval) { 2 }
-      let(:date) { Time.new(1997, 1, 1) }
+      let(:date) { Time.utc(1997, 1, 1) }
 
       it 'returns every other day' do
-        expect(frequency.next_occurrences).to eql [Time.new(1997, 1, 1)]
-        expect(frequency.next_occurrences).to eql [Time.new(1997, 1, 3)]
-        expect(frequency.next_occurrences).to eql [Time.new(1997, 1, 5)]
+        expect(frequency.next_occurrences).to eql [Time.utc(1997, 1, 1)]
+        expect(frequency.next_occurrences).to eql [Time.utc(1997, 1, 3)]
+        expect(frequency.next_occurrences).to eql [Time.utc(1997, 1, 5)]
       end
     end
 
     context 'on the last day of February' do
-      let(:date) { Time.new(1997, 2, 28) }
+      let(:date) { Time.utc(1997, 2, 28) }
 
       it 'goes into the next month' do
-        expect(frequency.next_occurrences).to eql [Time.new(1997, 2, 28)]
-        expect(frequency.next_occurrences).to eql [Time.new(1997, 3, 1)]
-        expect(frequency.next_occurrences).to eql [Time.new(1997, 3, 2)]
+        expect(frequency.next_occurrences).to eql [Time.utc(1997, 2, 28)]
+        expect(frequency.next_occurrences).to eql [Time.utc(1997, 3, 1)]
+        expect(frequency.next_occurrences).to eql [Time.utc(1997, 3, 2)]
       end
     end
 
     context 'on the last day of the year' do
-      let(:date) { Time.new(1997, 12, 31) }
+      let(:date) { Time.utc(1997, 12, 31) }
 
       it 'goes into the next year' do
-        expect(frequency.next_occurrences).to eql [Time.new(1997, 12, 31)]
-        expect(frequency.next_occurrences).to eql [Time.new(1998, 1, 1)]
-        expect(frequency.next_occurrences).to eql [Time.new(1998, 1, 2)]
+        expect(frequency.next_occurrences).to eql [Time.utc(1997, 12, 31)]
+        expect(frequency.next_occurrences).to eql [Time.utc(1998, 1, 1)]
+        expect(frequency.next_occurrences).to eql [Time.utc(1998, 1, 2)]
       end
     end
   end

--- a/spec/frequencies/daily_spec.rb
+++ b/spec/frequencies/daily_spec.rb
@@ -10,7 +10,7 @@ describe RRule::Daily do
   end
 
   describe '#possible_days' do
-    subject { described_class.new(context).possible_days }
+    subject { described_class.new(context, nil, nil, nil).possible_days }
 
     context 'on the first day of the year' do
       let(:date) { Date.new(1997, 1, 1)}
@@ -32,7 +32,7 @@ describe RRule::Daily do
   end
 
   describe '#advance' do
-    subject { described_class.new(context).advance }
+    subject { described_class.new(context, nil, nil, nil).advance }
 
     context 'on the first day of the year' do
       let(:date) { Date.new(1997, 1, 1)}

--- a/spec/frequencies/monthly_spec.rb
+++ b/spec/frequencies/monthly_spec.rb
@@ -6,7 +6,7 @@ describe RRule::Monthly do
     RRule::Context.new(
         { interval: interval },
         date,
-        'America/Los_Angeles'
+        'UTC'
     )
   end
   let(:filters) { [RRule::ByMonthDay.new([date.day], context)] }
@@ -19,44 +19,44 @@ describe RRule::Monthly do
     subject(:frequency) { described_class.new(context, filters, generator, timeset) }
 
     context 'with an interval of one' do
-      let(:date) { Time.new(1997, 1, 1) }
+      let(:date) { Time.utc(1997, 1, 1) }
 
       it 'returns sequential months' do
-        expect(frequency.next_occurrences).to eql [Time.new(1997, 1, 1)]
-        expect(frequency.next_occurrences).to eql [Time.new(1997, 2, 1)]
-        expect(frequency.next_occurrences).to eql [Time.new(1997, 3, 1)]
+        expect(frequency.next_occurrences).to eql [Time.utc(1997, 1, 1)]
+        expect(frequency.next_occurrences).to eql [Time.utc(1997, 2, 1)]
+        expect(frequency.next_occurrences).to eql [Time.utc(1997, 3, 1)]
       end
     end
 
     context 'with an interval of two' do
       let(:interval) { 2 }
-      let(:date) { Time.new(1997, 1, 1) }
+      let(:date) { Time.utc(1997, 1, 1) }
 
       it 'returns every other month' do
-        expect(frequency.next_occurrences).to eql [Time.new(1997, 1, 1)]
-        expect(frequency.next_occurrences).to eql [Time.new(1997, 3, 1)]
-        expect(frequency.next_occurrences).to eql [Time.new(1997, 5, 1)]
+        expect(frequency.next_occurrences).to eql [Time.utc(1997, 1, 1)]
+        expect(frequency.next_occurrences).to eql [Time.utc(1997, 3, 1)]
+        expect(frequency.next_occurrences).to eql [Time.utc(1997, 5, 1)]
       end
     end
 
     context 'on the last day of February' do
-      let(:date) { Time.new(1997, 2, 28) }
+      let(:date) { Time.utc(1997, 2, 28) }
 
       it 'returns the next three months' do
-        expect(frequency.next_occurrences).to eql [Time.new(1997, 2, 28)]
-        expect(frequency.next_occurrences).to eql [Time.new(1997, 3, 28)]
-        expect(frequency.next_occurrences).to eql [Time.new(1997, 4, 28)]
+        expect(frequency.next_occurrences).to eql [Time.utc(1997, 2, 28)]
+        expect(frequency.next_occurrences).to eql [Time.utc(1997, 3, 28)]
+        expect(frequency.next_occurrences).to eql [Time.utc(1997, 4, 28)]
       end
     end
 
     context 'on the last day of the year' do
-      let(:date) { Time.new(1997, 12, 31) }
+      let(:date) { Time.utc(1997, 12, 31) }
 
       it 'returns empty arrays for periods with no matching occurrences' do
-        expect(frequency.next_occurrences).to eql [Time.new(1997, 12, 31)]
-        expect(frequency.next_occurrences).to eql [Time.new(1998, 1, 31)]
+        expect(frequency.next_occurrences).to eql [Time.utc(1997, 12, 31)]
+        expect(frequency.next_occurrences).to eql [Time.utc(1998, 1, 31)]
         expect(frequency.next_occurrences).to eql []
-        expect(frequency.next_occurrences).to eql [Time.new(1998, 3, 31)]
+        expect(frequency.next_occurrences).to eql [Time.utc(1998, 3, 31)]
       end
     end
   end

--- a/spec/frequencies/monthly_spec.rb
+++ b/spec/frequencies/monthly_spec.rb
@@ -6,7 +6,7 @@ describe RRule::Monthly do
     RRule::Context.new(
         { interval: interval },
         date,
-        'UTC'
+        'America/Los_Angeles'
     )
   end
   let(:filters) { [RRule::ByMonthDay.new([date.day], context)] }
@@ -19,44 +19,44 @@ describe RRule::Monthly do
     subject(:frequency) { described_class.new(context, filters, generator, timeset) }
 
     context 'with an interval of one' do
-      let(:date) { Time.utc(1997, 1, 1) }
+      let(:date) { Time.zone.local(1997, 1, 1) }
 
       it 'returns sequential months' do
-        expect(frequency.next_occurrences).to eql [Time.utc(1997, 1, 1)]
-        expect(frequency.next_occurrences).to eql [Time.utc(1997, 2, 1)]
-        expect(frequency.next_occurrences).to eql [Time.utc(1997, 3, 1)]
+        expect(frequency.next_occurrences).to eql [Time.zone.local(1997, 1, 1)]
+        expect(frequency.next_occurrences).to eql [Time.zone.local(1997, 2, 1)]
+        expect(frequency.next_occurrences).to eql [Time.zone.local(1997, 3, 1)]
       end
     end
 
     context 'with an interval of two' do
       let(:interval) { 2 }
-      let(:date) { Time.utc(1997, 1, 1) }
+      let(:date) { Time.zone.local(1997, 1, 1) }
 
       it 'returns every other month' do
-        expect(frequency.next_occurrences).to eql [Time.utc(1997, 1, 1)]
-        expect(frequency.next_occurrences).to eql [Time.utc(1997, 3, 1)]
-        expect(frequency.next_occurrences).to eql [Time.utc(1997, 5, 1)]
+        expect(frequency.next_occurrences).to eql [Time.zone.local(1997, 1, 1)]
+        expect(frequency.next_occurrences).to eql [Time.zone.local(1997, 3, 1)]
+        expect(frequency.next_occurrences).to eql [Time.zone.local(1997, 5, 1)]
       end
     end
 
     context 'on the last day of February' do
-      let(:date) { Time.utc(1997, 2, 28) }
+      let(:date) { Time.zone.local(1997, 2, 28) }
 
       it 'returns the next three months' do
-        expect(frequency.next_occurrences).to eql [Time.utc(1997, 2, 28)]
-        expect(frequency.next_occurrences).to eql [Time.utc(1997, 3, 28)]
-        expect(frequency.next_occurrences).to eql [Time.utc(1997, 4, 28)]
+        expect(frequency.next_occurrences).to eql [Time.zone.local(1997, 2, 28)]
+        expect(frequency.next_occurrences).to eql [Time.zone.local(1997, 3, 28)]
+        expect(frequency.next_occurrences).to eql [Time.zone.local(1997, 4, 28)]
       end
     end
 
     context 'on the last day of the year' do
-      let(:date) { Time.utc(1997, 12, 31) }
+      let(:date) { Time.zone.local(1997, 12, 31) }
 
       it 'returns empty arrays for periods with no matching occurrences' do
-        expect(frequency.next_occurrences).to eql [Time.utc(1997, 12, 31)]
-        expect(frequency.next_occurrences).to eql [Time.utc(1998, 1, 31)]
+        expect(frequency.next_occurrences).to eql [Time.zone.local(1997, 12, 31)]
+        expect(frequency.next_occurrences).to eql [Time.zone.local(1998, 1, 31)]
         expect(frequency.next_occurrences).to eql []
-        expect(frequency.next_occurrences).to eql [Time.utc(1998, 3, 31)]
+        expect(frequency.next_occurrences).to eql [Time.zone.local(1998, 3, 31)]
       end
     end
   end

--- a/spec/frequencies/monthly_spec.rb
+++ b/spec/frequencies/monthly_spec.rb
@@ -12,7 +12,7 @@ describe RRule::Monthly do
   before(:each) { context.rebuild(1997, 1) }
 
   describe '#possible_days' do
-    subject { described_class.new(context).possible_days }
+    subject { described_class.new(context, nil, nil, nil).possible_days }
 
     context 'on the first day of the year' do
       let(:date) { Date.new(1997, 1, 1)}
@@ -34,7 +34,7 @@ describe RRule::Monthly do
   end
 
   describe '#advance' do
-    subject { described_class.new(context).advance }
+    subject { described_class.new(context, nil, nil, nil).advance }
 
     context 'on the first day of the year' do
       let(:date) { Date.new(1997, 1, 1)}

--- a/spec/frequencies/monthly_spec.rb
+++ b/spec/frequencies/monthly_spec.rb
@@ -1,57 +1,63 @@
 require 'spec_helper'
 
 describe RRule::Monthly do
+  let(:interval) { 1 }
   let(:context) do
     RRule::Context.new(
-        { interval: 1 },
+        { interval: interval },
         date,
         'America/Los_Angeles'
     )
   end
+  let(:filters) { [RRule::ByMonthDay.new([date.day], context)] }
+  let(:generator) { RRule::AllOccurrences.new(context) }
+  let(:timeset) { [{ hour: date.hour, minute: date.min, second: date.sec }] }
 
-  before(:each) { context.rebuild(1997, 1) }
+  before { context.rebuild(date.year, date.month) }
 
-  describe '#possible_days' do
-    subject { described_class.new(context, nil, nil, nil).possible_days }
+  describe '#next_occurrences' do
+    subject(:frequency) { described_class.new(context, filters, generator, timeset) }
 
-    context 'on the first day of the year' do
-      let(:date) { Date.new(1997, 1, 1)}
+    context 'with an interval of one' do
+      let(:date) { Time.new(1997, 1, 1) }
 
-      it { is_expected.to eql (0..30).to_a }
+      it 'returns sequential months' do
+        expect(frequency.next_occurrences).to eql [Time.new(1997, 1, 1)]
+        expect(frequency.next_occurrences).to eql [Time.new(1997, 2, 1)]
+        expect(frequency.next_occurrences).to eql [Time.new(1997, 3, 1)]
+      end
     end
 
-    context 'on a day in the first month' do
-      let(:date) { Date.new(1997, 1, 25)}
+    context 'with an interval of two' do
+      let(:interval) { 2 }
+      let(:date) { Time.new(1997, 1, 1) }
 
-      it { is_expected.to eql (0..30).to_a }
-    end
-
-    context 'on a day in the next month' do
-      let(:date) { Date.new(1997, 2, 25)}
-
-      it { is_expected.to eql (31..58).to_a }
-    end
-  end
-
-  describe '#advance' do
-    subject { described_class.new(context, nil, nil, nil).advance }
-
-    context 'on the first day of the year' do
-      let(:date) { Date.new(1997, 1, 1)}
-
-      it { is_expected.to eql date + 1.month }
+      it 'returns every other month' do
+        expect(frequency.next_occurrences).to eql [Time.new(1997, 1, 1)]
+        expect(frequency.next_occurrences).to eql [Time.new(1997, 3, 1)]
+        expect(frequency.next_occurrences).to eql [Time.new(1997, 5, 1)]
+      end
     end
 
     context 'on the last day of February' do
-      let(:date) { Date.new(1997, 2, 28)}
+      let(:date) { Time.new(1997, 2, 28) }
 
-      it { is_expected.to eql date + 1.month }
+      it 'returns the next three months' do
+        expect(frequency.next_occurrences).to eql [Time.new(1997, 2, 28)]
+        expect(frequency.next_occurrences).to eql [Time.new(1997, 3, 28)]
+        expect(frequency.next_occurrences).to eql [Time.new(1997, 4, 28)]
+      end
     end
 
     context 'on the last day of the year' do
-      let(:date) { Date.new(1997, 12, 31)}
+      let(:date) { Time.new(1997, 12, 31) }
 
-      it { is_expected.to eql date + 1.month }
+      it 'returns empty arrays for periods with no matching occurrences' do
+        expect(frequency.next_occurrences).to eql [Time.new(1997, 12, 31)]
+        expect(frequency.next_occurrences).to eql [Time.new(1998, 1, 31)]
+        expect(frequency.next_occurrences).to eql []
+        expect(frequency.next_occurrences).to eql [Time.new(1998, 3, 31)]
+      end
     end
   end
 end

--- a/spec/frequencies/simple_weekly_spec.rb
+++ b/spec/frequencies/simple_weekly_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+describe RRule::SimpleWeekly do
+  let(:context) { RRule::Context.new({ interval: interval }, date, nil) }
+  let(:frequency) { described_class.new(context, nil, nil, nil) }
+
+  describe '#next_occurrences' do
+    let(:date) { Date.new(1997, 1, 1) }
+
+    context 'with an interval of 1' do
+      let(:interval) { 1 }
+
+      it 'returns occurrences every week' do
+        expect(frequency.next_occurrences).to eql [Date.new(1997, 1, 1)]
+        expect(frequency.next_occurrences).to eql [Date.new(1997, 1, 8)]
+        expect(frequency.next_occurrences).to eql [Date.new(1997, 1, 15)]
+      end
+    end
+
+    context 'with an interval of 2' do
+      let(:interval) { 2 }
+
+      it 'returns occurrences every other week' do
+        expect(frequency.next_occurrences).to eql [Date.new(1997, 1, 1)]
+        expect(frequency.next_occurrences).to eql [Date.new(1997, 1, 15)]
+        expect(frequency.next_occurrences).to eql [Date.new(1997, 1, 29)]
+      end
+    end
+  end
+end

--- a/spec/frequencies/weekly_spec.rb
+++ b/spec/frequencies/weekly_spec.rb
@@ -6,7 +6,7 @@ describe RRule::Weekly do
     RRule::Context.new(
         { interval: interval, wkst: 1 },
         date,
-        'UTC'
+        'America/Los_Angeles'
     )
   end
   let(:filters) { [RRule::ByWeekDay.new([RRule::Weekday.new(date.wday)], context)] }
@@ -19,73 +19,73 @@ describe RRule::Weekly do
     subject(:frequency) { described_class.new(context, filters, generator, timeset) }
 
     context 'with an interval of one' do
-      let(:date) { Time.utc(1997, 1, 1) }
+      let(:date) { Time.zone.local(1997, 1, 1) }
 
       it 'returns sequential weeks' do
-        expect(frequency.next_occurrences).to eql [Time.utc(1997, 1, 1)]
-        expect(frequency.next_occurrences).to eql [Time.utc(1997, 1, 8)]
-        expect(frequency.next_occurrences).to eql [Time.utc(1997, 1, 15)]
+        expect(frequency.next_occurrences).to eql [Time.zone.local(1997, 1, 1)]
+        expect(frequency.next_occurrences).to eql [Time.zone.local(1997, 1, 8)]
+        expect(frequency.next_occurrences).to eql [Time.zone.local(1997, 1, 15)]
       end
     end
 
     context 'with an interval of two' do
       let(:interval) { 2 }
-      let(:date) { Time.utc(1997, 1, 1) }
+      let(:date) { Time.zone.local(1997, 1, 1) }
 
       it 'returns every other week' do
-        expect(frequency.next_occurrences).to eql [Time.utc(1997, 1, 1)]
-        expect(frequency.next_occurrences).to eql [Time.utc(1997, 1, 15)]
-        expect(frequency.next_occurrences).to eql [Time.utc(1997, 1, 29)]
+        expect(frequency.next_occurrences).to eql [Time.zone.local(1997, 1, 1)]
+        expect(frequency.next_occurrences).to eql [Time.zone.local(1997, 1, 15)]
+        expect(frequency.next_occurrences).to eql [Time.zone.local(1997, 1, 29)]
       end
     end
 
     context 'on the first day of the year with five days left in the week' do
-      let(:date) { Time.utc(1997, 1, 1) }
+      let(:date) { Time.zone.local(1997, 1, 1) }
 
       it 'returns the next three weeks' do
-        expect(frequency.next_occurrences).to eql [Time.utc(1997, 1, 1)]
-        expect(frequency.next_occurrences).to eql [Time.utc(1997, 1, 8)]
-        expect(frequency.next_occurrences).to eql [Time.utc(1997, 1, 15)]
+        expect(frequency.next_occurrences).to eql [Time.zone.local(1997, 1, 1)]
+        expect(frequency.next_occurrences).to eql [Time.zone.local(1997, 1, 8)]
+        expect(frequency.next_occurrences).to eql [Time.zone.local(1997, 1, 15)]
       end
     end
 
     context 'on a day in the first month with two days left in the week' do
-      let(:date) { Time.utc(1997, 1, 25) }
+      let(:date) { Time.zone.local(1997, 1, 25) }
 
       it 'returns the next three weeks' do
-        expect(frequency.next_occurrences).to eql [Time.utc(1997, 1, 25)]
-        expect(frequency.next_occurrences).to eql [Time.utc(1997, 2, 1)]
-        expect(frequency.next_occurrences).to eql [Time.utc(1997, 2, 8)]
+        expect(frequency.next_occurrences).to eql [Time.zone.local(1997, 1, 25)]
+        expect(frequency.next_occurrences).to eql [Time.zone.local(1997, 2, 1)]
+        expect(frequency.next_occurrences).to eql [Time.zone.local(1997, 2, 8)]
       end
     end
 
     context 'on a day in the next month with six days left in the week' do
-      let(:date) { Time.utc(1997, 2, 25) }
+      let(:date) { Time.zone.local(1997, 2, 25) }
 
       it 'returns the next three weeks' do
-        expect(frequency.next_occurrences).to eql [Time.utc(1997, 2, 25)]
-        expect(frequency.next_occurrences).to eql [Time.utc(1997, 3, 4)]
-        expect(frequency.next_occurrences).to eql [Time.utc(1997, 3, 11)]
+        expect(frequency.next_occurrences).to eql [Time.zone.local(1997, 2, 25)]
+        expect(frequency.next_occurrences).to eql [Time.zone.local(1997, 3, 4)]
+        expect(frequency.next_occurrences).to eql [Time.zone.local(1997, 3, 11)]
       end
     end
 
     context 'on the last day of February' do
-      let(:date) { Time.utc(1997, 2, 28) }
+      let(:date) { Time.zone.local(1997, 2, 28) }
 
       it 'returns the next three weeks' do
-        expect(frequency.next_occurrences).to eql [Time.utc(1997, 2, 28)]
-        expect(frequency.next_occurrences).to eql [Time.utc(1997, 3, 7)]
-        expect(frequency.next_occurrences).to eql [Time.utc(1997, 3, 14)]
+        expect(frequency.next_occurrences).to eql [Time.zone.local(1997, 2, 28)]
+        expect(frequency.next_occurrences).to eql [Time.zone.local(1997, 3, 7)]
+        expect(frequency.next_occurrences).to eql [Time.zone.local(1997, 3, 14)]
       end
     end
 
     context 'on the last day of the year' do
-      let(:date) { Time.utc(1997, 12, 31) }
+      let(:date) { Time.zone.local(1997, 12, 31) }
 
       it 'returns the next three weeks' do
-        expect(frequency.next_occurrences).to eql [Time.utc(1997, 12, 31)]
-        expect(frequency.next_occurrences).to eql [Time.utc(1998, 1, 7)]
-        expect(frequency.next_occurrences).to eql [Time.utc(1998, 1, 14)]
+        expect(frequency.next_occurrences).to eql [Time.zone.local(1997, 12, 31)]
+        expect(frequency.next_occurrences).to eql [Time.zone.local(1998, 1, 7)]
+        expect(frequency.next_occurrences).to eql [Time.zone.local(1998, 1, 14)]
       end
     end
   end

--- a/spec/frequencies/weekly_spec.rb
+++ b/spec/frequencies/weekly_spec.rb
@@ -12,7 +12,7 @@ describe RRule::Weekly do
   before(:each) { context.rebuild(1997, 1) }
 
   describe '#possible_days' do
-    subject { described_class.new(context).possible_days }
+    subject { described_class.new(context, nil, nil, nil).possible_days }
 
     context 'on the first day of the year with five days left in the week' do
       let(:date) { Date.new(1997, 1, 1)}
@@ -34,7 +34,7 @@ describe RRule::Weekly do
   end
 
   describe '#advance' do
-    subject { described_class.new(context).advance }
+    subject { described_class.new(context, nil, nil, nil).advance }
 
     context 'on the first day of the year' do
       let(:date) { Date.new(1997, 1, 1)}

--- a/spec/frequencies/weekly_spec.rb
+++ b/spec/frequencies/weekly_spec.rb
@@ -6,7 +6,7 @@ describe RRule::Weekly do
     RRule::Context.new(
         { interval: interval, wkst: 1 },
         date,
-        'America/Los_Angeles'
+        'UTC'
     )
   end
   let(:filters) { [RRule::ByWeekDay.new([RRule::Weekday.new(date.wday)], context)] }
@@ -19,73 +19,73 @@ describe RRule::Weekly do
     subject(:frequency) { described_class.new(context, filters, generator, timeset) }
 
     context 'with an interval of one' do
-      let(:date) { Time.new(1997, 1, 1) }
+      let(:date) { Time.utc(1997, 1, 1) }
 
       it 'returns sequential weeks' do
-        expect(frequency.next_occurrences).to eql [Time.new(1997, 1, 1)]
-        expect(frequency.next_occurrences).to eql [Time.new(1997, 1, 8)]
-        expect(frequency.next_occurrences).to eql [Time.new(1997, 1, 15)]
+        expect(frequency.next_occurrences).to eql [Time.utc(1997, 1, 1)]
+        expect(frequency.next_occurrences).to eql [Time.utc(1997, 1, 8)]
+        expect(frequency.next_occurrences).to eql [Time.utc(1997, 1, 15)]
       end
     end
 
     context 'with an interval of two' do
       let(:interval) { 2 }
-      let(:date) { Time.new(1997, 1, 1) }
+      let(:date) { Time.utc(1997, 1, 1) }
 
       it 'returns every other week' do
-        expect(frequency.next_occurrences).to eql [Time.new(1997, 1, 1)]
-        expect(frequency.next_occurrences).to eql [Time.new(1997, 1, 15)]
-        expect(frequency.next_occurrences).to eql [Time.new(1997, 1, 29)]
+        expect(frequency.next_occurrences).to eql [Time.utc(1997, 1, 1)]
+        expect(frequency.next_occurrences).to eql [Time.utc(1997, 1, 15)]
+        expect(frequency.next_occurrences).to eql [Time.utc(1997, 1, 29)]
       end
     end
 
     context 'on the first day of the year with five days left in the week' do
-      let(:date) { Time.new(1997, 1, 1) }
+      let(:date) { Time.utc(1997, 1, 1) }
 
       it 'returns the next three weeks' do
-        expect(frequency.next_occurrences).to eql [Time.new(1997, 1, 1)]
-        expect(frequency.next_occurrences).to eql [Time.new(1997, 1, 8)]
-        expect(frequency.next_occurrences).to eql [Time.new(1997, 1, 15)]
+        expect(frequency.next_occurrences).to eql [Time.utc(1997, 1, 1)]
+        expect(frequency.next_occurrences).to eql [Time.utc(1997, 1, 8)]
+        expect(frequency.next_occurrences).to eql [Time.utc(1997, 1, 15)]
       end
     end
 
     context 'on a day in the first month with two days left in the week' do
-      let(:date) { Time.new(1997, 1, 25) }
+      let(:date) { Time.utc(1997, 1, 25) }
 
       it 'returns the next three weeks' do
-        expect(frequency.next_occurrences).to eql [Time.new(1997, 1, 25)]
-        expect(frequency.next_occurrences).to eql [Time.new(1997, 2, 1)]
-        expect(frequency.next_occurrences).to eql [Time.new(1997, 2, 8)]
+        expect(frequency.next_occurrences).to eql [Time.utc(1997, 1, 25)]
+        expect(frequency.next_occurrences).to eql [Time.utc(1997, 2, 1)]
+        expect(frequency.next_occurrences).to eql [Time.utc(1997, 2, 8)]
       end
     end
 
     context 'on a day in the next month with six days left in the week' do
-      let(:date) { Time.new(1997, 2, 25) }
+      let(:date) { Time.utc(1997, 2, 25) }
 
       it 'returns the next three weeks' do
-        expect(frequency.next_occurrences).to eql [Time.new(1997, 2, 25)]
-        expect(frequency.next_occurrences).to eql [Time.new(1997, 3, 4)]
-        expect(frequency.next_occurrences).to eql [Time.new(1997, 3, 11)]
+        expect(frequency.next_occurrences).to eql [Time.utc(1997, 2, 25)]
+        expect(frequency.next_occurrences).to eql [Time.utc(1997, 3, 4)]
+        expect(frequency.next_occurrences).to eql [Time.utc(1997, 3, 11)]
       end
     end
 
     context 'on the last day of February' do
-      let(:date) { Time.new(1997, 2, 28) }
+      let(:date) { Time.utc(1997, 2, 28) }
 
       it 'returns the next three weeks' do
-        expect(frequency.next_occurrences).to eql [Time.new(1997, 2, 28)]
-        expect(frequency.next_occurrences).to eql [Time.new(1997, 3, 7)]
-        expect(frequency.next_occurrences).to eql [Time.new(1997, 3, 14)]
+        expect(frequency.next_occurrences).to eql [Time.utc(1997, 2, 28)]
+        expect(frequency.next_occurrences).to eql [Time.utc(1997, 3, 7)]
+        expect(frequency.next_occurrences).to eql [Time.utc(1997, 3, 14)]
       end
     end
 
     context 'on the last day of the year' do
-      let(:date) { Time.new(1997, 12, 31) }
+      let(:date) { Time.utc(1997, 12, 31) }
 
       it 'returns the next three weeks' do
-        expect(frequency.next_occurrences).to eql [Time.new(1997, 12, 31)]
-        expect(frequency.next_occurrences).to eql [Time.new(1998, 1, 7)]
-        expect(frequency.next_occurrences).to eql [Time.new(1998, 1, 14)]
+        expect(frequency.next_occurrences).to eql [Time.utc(1997, 12, 31)]
+        expect(frequency.next_occurrences).to eql [Time.utc(1998, 1, 7)]
+        expect(frequency.next_occurrences).to eql [Time.utc(1998, 1, 14)]
       end
     end
   end

--- a/spec/frequencies/weekly_spec.rb
+++ b/spec/frequencies/weekly_spec.rb
@@ -1,57 +1,92 @@
 require 'spec_helper'
 
 describe RRule::Weekly do
+  let(:interval) { 1 }
   let(:context) do
     RRule::Context.new(
-        { interval: 1, wkst: 1 },
+        { interval: interval, wkst: 1 },
         date,
         'America/Los_Angeles'
     )
   end
+  let(:filters) { [RRule::ByWeekDay.new([RRule::Weekday.new(date.wday)], context)] }
+  let(:generator) { RRule::AllOccurrences.new(context) }
+  let(:timeset) { [{ hour: date.hour, minute: date.min, second: date.sec }] }
 
-  before(:each) { context.rebuild(1997, 1) }
+  before { context.rebuild(date.year, date.month) }
 
-  describe '#possible_days' do
-    subject { described_class.new(context, nil, nil, nil).possible_days }
+  describe '#next_occurrences' do
+    subject(:frequency) { described_class.new(context, filters, generator, timeset) }
+
+    context 'with an interval of one' do
+      let(:date) { Time.new(1997, 1, 1) }
+
+      it 'returns sequential weeks' do
+        expect(frequency.next_occurrences).to eql [Time.new(1997, 1, 1)]
+        expect(frequency.next_occurrences).to eql [Time.new(1997, 1, 8)]
+        expect(frequency.next_occurrences).to eql [Time.new(1997, 1, 15)]
+      end
+    end
+
+    context 'with an interval of two' do
+      let(:interval) { 2 }
+      let(:date) { Time.new(1997, 1, 1) }
+
+      it 'returns every other week' do
+        expect(frequency.next_occurrences).to eql [Time.new(1997, 1, 1)]
+        expect(frequency.next_occurrences).to eql [Time.new(1997, 1, 15)]
+        expect(frequency.next_occurrences).to eql [Time.new(1997, 1, 29)]
+      end
+    end
 
     context 'on the first day of the year with five days left in the week' do
-      let(:date) { Date.new(1997, 1, 1)}
+      let(:date) { Time.new(1997, 1, 1) }
 
-      it { is_expected.to eql (0..4).to_a }
+      it 'returns the next three weeks' do
+        expect(frequency.next_occurrences).to eql [Time.new(1997, 1, 1)]
+        expect(frequency.next_occurrences).to eql [Time.new(1997, 1, 8)]
+        expect(frequency.next_occurrences).to eql [Time.new(1997, 1, 15)]
+      end
     end
 
     context 'on a day in the first month with two days left in the week' do
-      let(:date) { Date.new(1997, 1, 25)}
+      let(:date) { Time.new(1997, 1, 25) }
 
-      it { is_expected.to eql (24..25).to_a }
+      it 'returns the next three weeks' do
+        expect(frequency.next_occurrences).to eql [Time.new(1997, 1, 25)]
+        expect(frequency.next_occurrences).to eql [Time.new(1997, 2, 1)]
+        expect(frequency.next_occurrences).to eql [Time.new(1997, 2, 8)]
+      end
     end
 
     context 'on a day in the next month with six days left in the week' do
-      let(:date) { Date.new(1997, 2, 25)}
+      let(:date) { Time.new(1997, 2, 25) }
 
-      it { is_expected.to eql (55..60).to_a }
-    end
-  end
-
-  describe '#advance' do
-    subject { described_class.new(context, nil, nil, nil).advance }
-
-    context 'on the first day of the year' do
-      let(:date) { Date.new(1997, 1, 1)}
-
-      it { is_expected.to eql date.next_week }
+      it 'returns the next three weeks' do
+        expect(frequency.next_occurrences).to eql [Time.new(1997, 2, 25)]
+        expect(frequency.next_occurrences).to eql [Time.new(1997, 3, 4)]
+        expect(frequency.next_occurrences).to eql [Time.new(1997, 3, 11)]
+      end
     end
 
     context 'on the last day of February' do
-      let(:date) { Date.new(1997, 2, 28)}
+      let(:date) { Time.new(1997, 2, 28) }
 
-      it { is_expected.to eql date.next_week }
+      it 'returns the next three weeks' do
+        expect(frequency.next_occurrences).to eql [Time.new(1997, 2, 28)]
+        expect(frequency.next_occurrences).to eql [Time.new(1997, 3, 7)]
+        expect(frequency.next_occurrences).to eql [Time.new(1997, 3, 14)]
+      end
     end
 
     context 'on the last day of the year' do
-      let(:date) { Date.new(1997, 12, 31)}
+      let(:date) { Time.new(1997, 12, 31) }
 
-      it { is_expected.to eql date.next_week }
+      it 'returns the next three weeks' do
+        expect(frequency.next_occurrences).to eql [Time.new(1997, 12, 31)]
+        expect(frequency.next_occurrences).to eql [Time.new(1998, 1, 7)]
+        expect(frequency.next_occurrences).to eql [Time.new(1998, 1, 14)]
+      end
     end
   end
 end

--- a/spec/frequencies/yearly_spec.rb
+++ b/spec/frequencies/yearly_spec.rb
@@ -1,52 +1,54 @@
 require 'spec_helper'
 
 describe RRule::Yearly do
-  let(:date) { Date.new(1997, 1, 1) }
+  let(:interval) { 1 }
   let(:context) do
     RRule::Context.new(
-        { interval: 1, wkst: 1 },
+        { interval: interval, wkst: 1 },
         date,
         'America/Los_Angeles'
     )
   end
+  let(:filters) { [RRule::ByMonth.new([date.month], context), RRule::ByMonthDay.new([date.day], context)] }
+  let(:generator) { RRule::AllOccurrences.new(context) }
+  let(:timeset) { [{ hour: date.hour, minute: date.min, second: date.sec }] }
 
-  before(:each) { context.rebuild(1997, 1) }
+  before(:each) { context.rebuild(date.year, date.month) }
 
-  describe '#possible_days' do
-    subject { described_class.new(context, nil, nil, nil).possible_days }
-
-    context 'in a non leap year' do
-      before(:each) { context.rebuild(1997, 1) }
-
-      it { is_expected.to eql (0..364).to_a }
-    end
-
-    context 'in a leap year' do
-      before(:each) { context.rebuild(2000, 1) }
-
-      it { is_expected.to eql (0..365).to_a }
-    end
-  end
-
-  describe '#advance' do
-    subject { described_class.new(context, nil, nil, nil).advance }
+  describe '#next_occurrences' do
+    subject(:frequency) { described_class.new(context, filters, generator, timeset) }
 
     context 'on the first day of the year' do
-      let(:date) { Date.new(1997, 1, 1)}
+      let(:date) { Time.new(1997, 1, 1) }
 
-      it { is_expected.to eql date + 1.year }
+      it 'returns the next three years' do
+        expect(frequency.next_occurrences).to eql [Time.new(1997, 1, 1)]
+        expect(frequency.next_occurrences).to eql [Time.new(1998, 1, 1)]
+        expect(frequency.next_occurrences).to eql [Time.new(1999, 1, 1)]
+      end
     end
 
-    context 'on the last day of February' do
-      let(:date) { Date.new(1997, 2, 28)}
+    context 'on the last day of February in a leap year' do
+      let(:date) { Time.new(2000, 2, 29) }
 
-      it { is_expected.to eql date + 1.year }
+      it 'skips non-leap years' do
+        expect(frequency.next_occurrences).to eql [Time.new(2000, 2, 29)]
+        expect(frequency.next_occurrences).to eql []
+        expect(frequency.next_occurrences).to eql []
+        expect(frequency.next_occurrences).to eql []
+        expect(frequency.next_occurrences).to eql [Time.new(2004, 2, 29)]
+      end
     end
 
-    context 'on the last day of the year' do
-      let(:date) { Date.new(1997, 12, 31)}
+    context 'with an interval of two' do
+      let(:interval) { 2 }
+      let(:date) { Time.new(1997, 1, 1) }
 
-      it { is_expected.to eql date + 1.year }
+      it 'returns every other year' do
+        expect(frequency.next_occurrences).to eql [Time.new(1997, 1, 1)]
+        expect(frequency.next_occurrences).to eql [Time.new(1999, 1, 1)]
+        expect(frequency.next_occurrences).to eql [Time.new(2001, 1, 1)]
+      end
     end
   end
 end

--- a/spec/frequencies/yearly_spec.rb
+++ b/spec/frequencies/yearly_spec.rb
@@ -6,7 +6,7 @@ describe RRule::Yearly do
     RRule::Context.new(
         { interval: interval, wkst: 1 },
         date,
-        'UTC'
+        'America/Los_Angeles'
     )
   end
   let(:filters) { [RRule::ByMonth.new([date.month], context), RRule::ByMonthDay.new([date.day], context)] }
@@ -19,35 +19,35 @@ describe RRule::Yearly do
     subject(:frequency) { described_class.new(context, filters, generator, timeset) }
 
     context 'on the first day of the year' do
-      let(:date) { Time.utc(1997, 1, 1) }
+      let(:date) { Time.zone.local(1997, 1, 1) }
 
       it 'returns the next three years' do
-        expect(frequency.next_occurrences).to eql [Time.utc(1997, 1, 1)]
-        expect(frequency.next_occurrences).to eql [Time.utc(1998, 1, 1)]
-        expect(frequency.next_occurrences).to eql [Time.utc(1999, 1, 1)]
+        expect(frequency.next_occurrences).to eql [Time.zone.local(1997, 1, 1)]
+        expect(frequency.next_occurrences).to eql [Time.zone.local(1998, 1, 1)]
+        expect(frequency.next_occurrences).to eql [Time.zone.local(1999, 1, 1)]
       end
     end
 
     context 'on the last day of February in a leap year' do
-      let(:date) { Time.utc(2000, 2, 29) }
+      let(:date) { Time.zone.local(2000, 2, 29) }
 
       it 'skips non-leap years' do
-        expect(frequency.next_occurrences).to eql [Time.utc(2000, 2, 29)]
+        expect(frequency.next_occurrences).to eql [Time.zone.local(2000, 2, 29)]
         expect(frequency.next_occurrences).to eql []
         expect(frequency.next_occurrences).to eql []
         expect(frequency.next_occurrences).to eql []
-        expect(frequency.next_occurrences).to eql [Time.utc(2004, 2, 29)]
+        expect(frequency.next_occurrences).to eql [Time.zone.local(2004, 2, 29)]
       end
     end
 
     context 'with an interval of two' do
       let(:interval) { 2 }
-      let(:date) { Time.utc(1997, 1, 1) }
+      let(:date) { Time.zone.local(1997, 1, 1) }
 
       it 'returns every other year' do
-        expect(frequency.next_occurrences).to eql [Time.utc(1997, 1, 1)]
-        expect(frequency.next_occurrences).to eql [Time.utc(1999, 1, 1)]
-        expect(frequency.next_occurrences).to eql [Time.utc(2001, 1, 1)]
+        expect(frequency.next_occurrences).to eql [Time.zone.local(1997, 1, 1)]
+        expect(frequency.next_occurrences).to eql [Time.zone.local(1999, 1, 1)]
+        expect(frequency.next_occurrences).to eql [Time.zone.local(2001, 1, 1)]
       end
     end
   end

--- a/spec/frequencies/yearly_spec.rb
+++ b/spec/frequencies/yearly_spec.rb
@@ -13,7 +13,7 @@ describe RRule::Yearly do
   before(:each) { context.rebuild(1997, 1) }
 
   describe '#possible_days' do
-    subject { described_class.new(context).possible_days }
+    subject { described_class.new(context, nil, nil, nil).possible_days }
 
     context 'in a non leap year' do
       before(:each) { context.rebuild(1997, 1) }
@@ -29,7 +29,7 @@ describe RRule::Yearly do
   end
 
   describe '#advance' do
-    subject { described_class.new(context).advance }
+    subject { described_class.new(context, nil, nil, nil).advance }
 
     context 'on the first day of the year' do
       let(:date) { Date.new(1997, 1, 1)}

--- a/spec/frequencies/yearly_spec.rb
+++ b/spec/frequencies/yearly_spec.rb
@@ -6,7 +6,7 @@ describe RRule::Yearly do
     RRule::Context.new(
         { interval: interval, wkst: 1 },
         date,
-        'America/Los_Angeles'
+        'UTC'
     )
   end
   let(:filters) { [RRule::ByMonth.new([date.month], context), RRule::ByMonthDay.new([date.day], context)] }
@@ -19,35 +19,35 @@ describe RRule::Yearly do
     subject(:frequency) { described_class.new(context, filters, generator, timeset) }
 
     context 'on the first day of the year' do
-      let(:date) { Time.new(1997, 1, 1) }
+      let(:date) { Time.utc(1997, 1, 1) }
 
       it 'returns the next three years' do
-        expect(frequency.next_occurrences).to eql [Time.new(1997, 1, 1)]
-        expect(frequency.next_occurrences).to eql [Time.new(1998, 1, 1)]
-        expect(frequency.next_occurrences).to eql [Time.new(1999, 1, 1)]
+        expect(frequency.next_occurrences).to eql [Time.utc(1997, 1, 1)]
+        expect(frequency.next_occurrences).to eql [Time.utc(1998, 1, 1)]
+        expect(frequency.next_occurrences).to eql [Time.utc(1999, 1, 1)]
       end
     end
 
     context 'on the last day of February in a leap year' do
-      let(:date) { Time.new(2000, 2, 29) }
+      let(:date) { Time.utc(2000, 2, 29) }
 
       it 'skips non-leap years' do
-        expect(frequency.next_occurrences).to eql [Time.new(2000, 2, 29)]
+        expect(frequency.next_occurrences).to eql [Time.utc(2000, 2, 29)]
         expect(frequency.next_occurrences).to eql []
         expect(frequency.next_occurrences).to eql []
         expect(frequency.next_occurrences).to eql []
-        expect(frequency.next_occurrences).to eql [Time.new(2004, 2, 29)]
+        expect(frequency.next_occurrences).to eql [Time.utc(2004, 2, 29)]
       end
     end
 
     context 'with an interval of two' do
       let(:interval) { 2 }
-      let(:date) { Time.new(1997, 1, 1) }
+      let(:date) { Time.utc(1997, 1, 1) }
 
       it 'returns every other year' do
-        expect(frequency.next_occurrences).to eql [Time.new(1997, 1, 1)]
-        expect(frequency.next_occurrences).to eql [Time.new(1999, 1, 1)]
-        expect(frequency.next_occurrences).to eql [Time.new(2001, 1, 1)]
+        expect(frequency.next_occurrences).to eql [Time.utc(1997, 1, 1)]
+        expect(frequency.next_occurrences).to eql [Time.utc(1999, 1, 1)]
+        expect(frequency.next_occurrences).to eql [Time.utc(2001, 1, 1)]
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,3 +19,5 @@ RSpec.configure do |config|
     mocks.verify_partial_doubles = true
   end
 end
+
+Time.zone = 'America/Los_Angeles'


### PR DESCRIPTION
Using a different strategy for the simple weekly case with no
additional filters results in a 40-50% faster expansion for those rules,
when expanded over a short timespan of a month (I expect that the
speedup would be even larger when expanding over long periods of time,
as in those cases the time taken to expand is proportionally larger than
the initialization time of parsing options, etc).

I think it makes sense to start with this case for now and gain some
confidence that it doesn't miss any edge cases, but this strategy
(identifying simple cases and handing them separately than the cases
that require filters) might be a good one to apply here in general.

Not ready to merge this yet, as I want to update the specs for the frequencies
if this approach looks good, but wanted to get a PR out to collect feedback.