### PR TITLE
Add support for BYHOUR, BYMINUTE, BYSECOND

### DIFF
--- a/lib/rrule.rb
+++ b/lib/rrule.rb
@@ -18,6 +18,7 @@ module RRule
   autoload :ByYearDay, 'rrule/filters/by_year_day'
   autoload :ByMonthDay, 'rrule/filters/by_month_day'
 
+  autoload :Generator, 'rrule/generators/generator'
   autoload :AllOccurrences, 'rrule/generators/all_occurrences'
   autoload :BySetPosition, 'rrule/generators/by_set_position'
 

--- a/lib/rrule/frequencies/simple_weekly.rb
+++ b/lib/rrule/frequencies/simple_weekly.rb
@@ -3,7 +3,7 @@ module RRule
     def next_occurrences
       this_occurrence = current_date
       @current_date += context.options[:interval].weeks
-      [this_occurrence]
+      generator.process_timeset(this_occurrence, timeset)
     end
   end
 end

--- a/lib/rrule/generators/all_occurrences.rb
+++ b/lib/rrule/generators/all_occurrences.rb
@@ -1,25 +1,8 @@
 module RRule
-  class AllOccurrences
-    attr_reader :context
-
-    def initialize(context)
-      @context = context
-    end
-
+  class AllOccurrences < Generator
     def combine_dates_and_times(dayset, timeset)
       dayset.compact.map { |i| context.first_day_of_year + i }.flat_map do |date|
-        timeset.map do |time|
-          Time.use_zone(context.tz) do
-            Time.zone.local(
-                date.year,
-                date.month,
-                date.day,
-                time[:hour],
-                time[:minute],
-                time[:second]
-            )
-          end
-        end
+        process_timeset(date, timeset)
       end
     end
   end

--- a/lib/rrule/generators/by_set_position.rb
+++ b/lib/rrule/generators/by_set_position.rb
@@ -1,26 +1,15 @@
 module RRule
-  class BySetPosition
-    attr_reader :by_set_positions, :context
+  class BySetPosition < Generator
+    attr_reader :by_set_positions
 
     def initialize(by_set_positions, context)
       @by_set_positions = by_set_positions
-      @context = context
+      super(context)
     end
 
     def combine_dates_and_times(dayset, timeset)
       valid_dates(dayset).flat_map do |date|
-        timeset.map do |time|
-          Time.use_zone(context.tz) do
-            Time.zone.local(
-                date.year,
-                date.month,
-                date.day,
-                time[:hour],
-                time[:minute],
-                time[:second]
-            )
-          end
-        end
+        process_timeset(date, timeset)
       end
     end
 

--- a/lib/rrule/generators/generator.rb
+++ b/lib/rrule/generators/generator.rb
@@ -1,0 +1,34 @@
+module RRule
+  class Generator
+    attr_reader :context
+
+    def initialize(context)
+      @context = context
+    end
+
+    def process_timeset(date, timeset)
+      timeset.map do |time|
+        hour_sets = (
+          Array.wrap(time[:hour]).sort.map do |hour|
+            Array.wrap(time[:minute]).sort.map do  |minute|
+              Array.wrap(time[:second]).sort.map{ |second| [hour, minute, second]}
+            end
+          end
+        ).flatten(2)
+
+        Time.use_zone(context.tz) do
+          hour_sets.map do |hour, minute, second|
+            Time.zone.local(
+              date.year,
+              date.month,
+              date.day,
+              hour,
+              minute,
+              second
+            )
+          end
+        end
+      end.flatten
+    end
+  end
+end

--- a/lib/rrule/rule.rb
+++ b/lib/rrule/rule.rb
@@ -120,6 +120,12 @@ module RRule
           i = Integer(value) rescue 0
           raise InvalidRRule, "INTERVAL must be a positive integer" unless i > 0
           options[:interval] = i
+        when 'BYHOUR'
+          options[:byhour] = value.split(',').compact.map(&:to_i)
+        when 'BYMINUTE'
+          options[:byminute] = value.split(',').compact.map(&:to_i)
+        when 'BYSECOND'
+          options[:bysecond] = value.split(',').compact.map(&:to_i)
         when 'BYDAY'
           options[:byweekday] = value.split(',').map { |day| Weekday.parse(day) }
         when 'BYSETPOS'
@@ -156,7 +162,7 @@ module RRule
         options[:byweekday], options[:bynweekday] = options[:byweekday].partition { |wday| wday.ordinal.nil? }
       end
 
-      options[:timeset] = [{ hour: dtstart.hour, minute: dtstart.min, second: dtstart.sec }]
+      options[:timeset] = [{ hour: (options[:byhour].presence || dtstart.hour), minute: (options[:byminute].presence || dtstart.min), second: (options[:bysecond].presence || dtstart.sec) }]
 
       options
     end

--- a/spec/frequencies/simple_weekly_spec.rb
+++ b/spec/frequencies/simple_weekly_spec.rb
@@ -1,19 +1,21 @@
 require 'spec_helper'
 
 describe RRule::SimpleWeekly do
-  let(:context) { RRule::Context.new({ interval: interval }, date, nil) }
-  let(:frequency) { described_class.new(context, nil, nil, nil) }
+  let(:context) { RRule::Context.new({ interval: interval }, date, 'America/Los_Angeles') }
+  let(:frequency) { described_class.new(context, nil, generator, timeset) }
+  let(:generator) { RRule::AllOccurrences.new(context) }
+  let(:timeset) { [{ hour: date.hour, minute: date.min, second: date.sec }] }
 
   describe '#next_occurrences' do
-    let(:date) { Date.new(1997, 1, 1) }
+    let(:date) { Time.zone.local(1997, 1, 1) }
 
     context 'with an interval of 1' do
       let(:interval) { 1 }
 
       it 'returns occurrences every week' do
-        expect(frequency.next_occurrences).to eql [Date.new(1997, 1, 1)]
-        expect(frequency.next_occurrences).to eql [Date.new(1997, 1, 8)]
-        expect(frequency.next_occurrences).to eql [Date.new(1997, 1, 15)]
+        expect(frequency.next_occurrences).to eql [Time.zone.local(1997, 1, 1)]
+        expect(frequency.next_occurrences).to eql [Time.zone.local(1997, 1, 8)]
+        expect(frequency.next_occurrences).to eql [Time.zone.local(1997, 1, 15)]
       end
     end
 
@@ -21,9 +23,9 @@ describe RRule::SimpleWeekly do
       let(:interval) { 2 }
 
       it 'returns occurrences every other week' do
-        expect(frequency.next_occurrences).to eql [Date.new(1997, 1, 1)]
-        expect(frequency.next_occurrences).to eql [Date.new(1997, 1, 15)]
-        expect(frequency.next_occurrences).to eql [Date.new(1997, 1, 29)]
+        expect(frequency.next_occurrences).to eql [Time.zone.local(1997, 1, 1)]
+        expect(frequency.next_occurrences).to eql [Time.zone.local(1997, 1, 15)]
+        expect(frequency.next_occurrences).to eql [Time.zone.local(1997, 1, 29)]
       end
     end
   end

--- a/spec/generators/generator_spec.rb
+++ b/spec/generators/generator_spec.rb
@@ -1,0 +1,110 @@
+require 'spec_helper'
+
+describe RRule::Generator do
+  let(:context) do
+    RRule::Context.new(
+        { interval: 1, wkst: 1 },
+        Time.parse('Wed Jan  1 00:00:00 PST 1997'),
+        'America/Los_Angeles'
+    )
+  end
+
+  around(:each) do |example|
+    Time.use_zone('America/Los_Angeles') do
+      example.run
+    end
+  end
+
+  before(:each) { context.rebuild(1997, 1) }
+
+  describe '#process_timeset' do
+    describe "single timeset" do
+      subject { described_class.new(context).process_timeset(date, timeset)}
+
+      context 'with a timeset with only 1 set' do
+        let(:date) { Time.parse('Wed Jan  1 00:11:22 PST 1997') }
+        let(:timeset) { [{ hour: 12, minute: 30, second: 15 }] }
+
+        it { is_expected.to match_array [Time.parse('Wed Jan  1 12:30:15 PST 1997')] }
+      end
+
+      context 'with multiple hours in the timeset' do
+        let(:date) { Time.parse('Wed Jan  1 00:11:22 PST 1997') }
+        let(:timeset) { [{ hour: [12, 15], minute: 30, second: 15 }] }
+
+        it { is_expected.to match_array [Time.parse('Wed Jan  1 12:30:15 PST 1997'), Time.parse('Wed Jan  1 15:30:15 PST 1997')] }
+      end
+
+      context 'with multiple minutes in the timeset' do
+        let(:date) { Time.parse('Wed Jan  1 00:11:22 PST 1997') }
+        let(:timeset) { [{ hour: [12], minute: [15, 30], second: 15 }] }
+
+        it { is_expected.to match_array [Time.parse('Wed Jan  1 12:15:15 PST 1997'), Time.parse('Wed Jan  1 12:30:15 PST 1997')] }
+      end
+
+      context 'with multiple seconds in the timeset' do
+        let(:date) { Time.parse('Wed Jan  1 00:11:22 PST 1997') }
+        let(:timeset) { [{ hour: [12], minute: [30], second: [15, 59] }] }
+
+        it { is_expected.to match_array [Time.parse('Wed Jan  1 12:30:15 PST 1997'), Time.parse('Wed Jan  1 12:30:59 PST 1997')] }
+      end
+
+      context 'with multiple hours, minutes, and seconds in the timeset' do
+        let(:date) { Time.parse('Wed Jan  1 00:11:22 PST 1997') }
+        let(:timeset) { [{ hour: [12, 20], minute: [30, 55], second: [15, 59] }] }
+
+        it { is_expected.to eq [
+          Time.parse('Wed Jan  1 12:30:15 PST 1997'),
+          Time.parse('Wed Jan  1 12:30:59 PST 1997'),
+          Time.parse('Wed Jan  1 12:55:15 PST 1997'),
+          Time.parse('Wed Jan  1 12:55:59 PST 1997'),
+          Time.parse('Wed Jan  1 20:30:15 PST 1997'),
+          Time.parse('Wed Jan  1 20:30:59 PST 1997'),
+          Time.parse('Wed Jan  1 20:55:15 PST 1997'),
+          Time.parse('Wed Jan  1 20:55:59 PST 1997'),
+        ] }
+      end
+
+      context 'with multiple hours, minutes, and seconds in the timeset, unsorted' do
+        let(:date) { Time.parse('Wed Jan  1 00:11:22 PST 1997') }
+        let(:timeset) { [{ hour: [20, 12], minute: [55, 30], second: [59, 15] }] }
+
+        it { is_expected.to eq [
+          Time.parse('Wed Jan  1 12:30:15 PST 1997'),
+          Time.parse('Wed Jan  1 12:30:59 PST 1997'),
+          Time.parse('Wed Jan  1 12:55:15 PST 1997'),
+          Time.parse('Wed Jan  1 12:55:59 PST 1997'),
+          Time.parse('Wed Jan  1 20:30:15 PST 1997'),
+          Time.parse('Wed Jan  1 20:30:59 PST 1997'),
+          Time.parse('Wed Jan  1 20:55:15 PST 1997'),
+          Time.parse('Wed Jan  1 20:55:59 PST 1997'),
+        ] }
+      end
+    end
+  end
+
+  describe "multiple timesets" do
+    subject { described_class.new(context).process_timeset(date, timeset)}
+
+      context 'with multiple timsets' do
+        let(:date) { Time.parse('Wed Jan  1 00:11:22 PST 1997') }
+        let(:timeset) { [{ hour: 12, minute: 30, second: 15 }, { hour: 18, minute: 45, second: 20 }] }
+
+        it { is_expected.to eq [Time.parse('Wed Jan  1 12:30:15 PST 1997'), Time.parse('Wed Jan  1 18:45:20 PST 1997')] }
+      end
+
+      context 'with multiple timsets with multiple hour sets' do
+        let(:date) { Time.parse('Wed Jan  1 00:11:22 PST 1997') }
+        let(:timeset) { [{ hour: [12, 20], minute: 30, second: [15, 45] }, { hour: 18, minute: [22, 45], second: 20 }] }
+
+        it { is_expected.to eq [
+          Time.parse('Wed Jan  1 12:30:15 PST 1997'),
+          Time.parse('Wed Jan  1 12:30:45 PST 1997'),
+          Time.parse('Wed Jan  1 20:30:15 PST 1997'),
+          Time.parse('Wed Jan  1 20:30:45 PST 1997'),
+          Time.parse('Wed Jan  1 18:22:20 PST 1997'),
+          Time.parse('Wed Jan  1 18:45:20 PST 1997')
+        ] }
+      end
+  end
+end

--- a/spec/rule_spec.rb
+++ b/spec/rule_spec.rb
@@ -1715,6 +1715,25 @@ describe RRule::Rule do
   end
 
   describe '#between' do
+    it 'returns the correct result with an rrule of FREQ=WEEKLY;BYSECOND=59;BYMINUTE=59;BYHOUR=23;WKST=SU' do
+      rrule = "FREQ=WEEKLY;BYSECOND=59;BYMINUTE=59;BYHOUR=23;WKST=SU"
+      dtstart = DateTime.parse("2018-02-04 04:00:00 +1000")
+      timezone = 'Brisbane'
+
+      rrule = RRule::Rule.new(rrule, dtstart: dtstart, tzid: timezone)
+      expect(rrule.between(Time.parse('Sun, 08 Apr 2018 00:00:00 +0000'), Time.parse('Fri, 08 Jun 2018 23:59:59 +0000'))).to match_array([
+        Time.parse('Sun, 08 Apr 2018 23:59:59 +1000'),
+        Time.parse('Sun, 15 Apr 2018 23:59:59 +1000'),
+        Time.parse('Sun, 22 Apr 2018 23:59:59 +1000'),
+        Time.parse('Sun, 29 Apr 2018 23:59:59 +1000'),
+        Time.parse('Sun, 06 May 2018 23:59:59 +1000'),
+        Time.parse('Sun, 13 May 2018 23:59:59 +1000'),
+        Time.parse('Sun, 20 May 2018 23:59:59 +1000'),
+        Time.parse('Sun, 27 May 2018 23:59:59 +1000'),
+        Time.parse('Sun, 03 Jun 2018 23:59:59 +1000'),
+      ])
+    end
+
     it 'returns the correct result with an rrule of FREQ=DAILY;INTERVAL=2' do
       rrule = 'FREQ=DAILY;INTERVAL=2'
       dtstart = Time.parse('Tue Sep  2 06:00:00 PDT 1997')
@@ -2046,6 +2065,69 @@ describe RRule::Rule do
       end_time = Time.parse('Wed Aug 31 21:59:59 PDT 2016')
       expect(rule.between(start_time, end_time)).to eql([expected_instance])
     end
+  end
+
+  it 'returns the correct result with an rrule of FREQ=WEEKLY;BYMONTH=1,3;COUNT=4;BYHOUR=2' do
+    rrule = 'FREQ=WEEKLY;BYMONTH=1,3;COUNT=4;BYHOUR=2'
+    dtstart = Time.parse('Tue Sep  2 09:00:00 PDT 1997')
+    timezone = 'America/Los_Angeles'
+
+    rrule = RRule::Rule.new(rrule, dtstart: dtstart, tzid: timezone)
+
+    expect(rrule.all).to match_array([
+      Time.parse('Tue Jan  6 02:00:00 PST 1998'),
+      Time.parse('Tue Jan 13 02:00:00 PST 1998'),
+      Time.parse('Tue Jan 20 02:00:00 PST 1998'),
+      Time.parse('Tue Jan 27 02:00:00 PST 1998')
+    ])
+  end
+
+  it 'returns the correct result with an rrule of FREQ=WEEKLY;BYMONTH=1,3;COUNT=4;BYHOUR=2;BYMINUTE=44' do
+    rrule = 'FREQ=WEEKLY;BYMONTH=1,3;COUNT=4;BYHOUR=2;BYMINUTE=44'
+    dtstart = Time.parse('Tue Sep  2 09:00:00 PDT 1997')
+    timezone = 'America/Los_Angeles'
+
+    rrule = RRule::Rule.new(rrule, dtstart: dtstart, tzid: timezone)
+    expect(rrule.all).to match_array([
+      Time.parse('Tue Jan  6 02:44:00 PST 1998'),
+      Time.parse('Tue Jan 13 02:44:00 PST 1998'),
+      Time.parse('Tue Jan 20 02:44:00 PST 1998'),
+      Time.parse('Tue Jan 27 02:44:00 PST 1998')
+    ])
+  end
+
+  it 'returns the correct result with an rrule of FREQ=WEEKLY;BYMONTH=1,3;COUNT=24;BYHOUR=2,4,6;BYMINUTE=33,22' do
+    rrule = 'FREQ=WEEKLY;BYMONTH=1,3;COUNT=24;BYHOUR=2,4,6;BYMINUTE=33,22'
+    dtstart = Time.parse('Tue Sep  2 09:23:42 PDT 1997')
+    timezone = 'America/Los_Angeles'
+
+    rrule = RRule::Rule.new(rrule, dtstart: dtstart, tzid: timezone)
+    expect(rrule.all).to match_array([
+      Time.parse('Tue Jan  6 02:22:42 PST 1998'),
+      Time.parse('Tue Jan  6 02:33:42 PST 1998'),
+      Time.parse('Tue Jan  6 04:22:42 PST 1998'),
+      Time.parse('Tue Jan  6 04:33:42 PST 1998'),
+      Time.parse('Tue Jan  6 06:22:42 PST 1998'),
+      Time.parse('Tue Jan  6 06:33:42 PST 1998'),
+      Time.parse('Tue Jan 13 02:22:42 PST 1998'),
+      Time.parse('Tue Jan 13 02:33:42 PST 1998'),
+      Time.parse('Tue Jan 13 04:22:42 PST 1998'),
+      Time.parse('Tue Jan 13 04:33:42 PST 1998'),
+      Time.parse('Tue Jan 13 06:22:42 PST 1998'),
+      Time.parse('Tue Jan 13 06:33:42 PST 1998'),
+      Time.parse('Tue Jan 20 02:22:42 PST 1998'),
+      Time.parse('Tue Jan 20 02:33:42 PST 1998'),
+      Time.parse('Tue Jan 20 04:22:42 PST 1998'),
+      Time.parse('Tue Jan 20 04:33:42 PST 1998'),
+      Time.parse('Tue Jan 20 06:22:42 PST 1998'),
+      Time.parse('Tue Jan 20 06:33:42 PST 1998'),
+      Time.parse('Tue Jan 27 02:22:42 PST 1998'),
+      Time.parse('Tue Jan 27 02:33:42 PST 1998'),
+      Time.parse('Tue Jan 27 04:22:42 PST 1998'),
+      Time.parse('Tue Jan 27 04:33:42 PST 1998'),
+      Time.parse('Tue Jan 27 06:22:42 PST 1998'),
+      Time.parse('Tue Jan 27 06:33:42 PST 1998')
+    ])
   end
 
   describe 'validation' do


### PR DESCRIPTION
Refactor Generators to support timesets w/ multiple hours/minutes/secs
* In order to add support for BYHOUR/BYMINUTE/BYSECOND, we need to
  update the generators to allow timesets with multiple values for
  hour/minute/second to be processed
* We build a flat map of all the hour sets each time set considers,
  then iterate over that map to build the times (in the context's
  timezone)
* We also had to fix SimpleWeekly tests to work now that we use the
  generator to process timesets

Add support for BYHOUR/BYMINUTE/BYSECOND in `RRule::Rule`
* `RRule::Rule` now accepts BYHOUR/BYMINUTE/BYSECOND options, and
  uses them when building the next dates in the RRULE
  * If any of these options are missing, the dtstart's hour/minute/
    second is used, as per the RRULE specification