### PR TITLE
Improve performance of `between` method

### DIFF
--- a/lib/rrule/frequencies/frequency.rb
+++ b/lib/rrule/frequencies/frequency.rb
@@ -2,9 +2,9 @@ module RRule
   class Frequency
     attr_reader :current_date, :filters, :generator, :timeset
 
-    def initialize(context, filters, generator, timeset)
+    def initialize(context, filters, generator, timeset, start_date: nil)
       @context = context
-      @current_date = context.dtstart
+      @current_date = start_date.presence || context.dtstart
       @filters = filters
       @generator = generator
       @timeset = timeset

--- a/lib/rrule/frequencies/simple_weekly.rb
+++ b/lib/rrule/frequencies/simple_weekly.rb
@@ -1,9 +1,22 @@
 module RRule
   class SimpleWeekly < Frequency
     def next_occurrences
+      correct_current_date_if_needed
       this_occurrence = current_date
       @current_date += context.options[:interval].weeks
       [this_occurrence]
+    end
+
+    def correct_current_date_if_needed
+      if context.options[:byweekday].present?
+        target_wday = context.options[:byweekday].first.index
+      else
+        target_wday = context.dtstart.wday
+      end
+
+      while @current_date.wday != target_wday
+        @current_date = @current_date + 1.day
+      end
     end
   end
 end

--- a/lib/rrule/rule.rb
+++ b/lib/rrule/rule.rb
@@ -20,14 +20,19 @@ module RRule
     def between(start_date, end_date, limit: nil)
       floored_start_date = floor_to_seconds(start_date)
       floored_end_date = floor_to_seconds(end_date)
-      all_until(end_date: floored_end_date, limit: limit).reject { |instance| instance < floored_start_date }
+      all_until(start_date: floored_start_date, end_date: floored_end_date, limit: limit).reject { |instance| instance < floored_start_date }
     end
 
-    def each
-      return enum_for(:each) unless block_given?
+    def each(floor_date: nil)
+      floor_date ||= dtstart
+      # If we have a COUNT or INTERVAL option, we have to start at dtstart, because those are relative to dtstart
+      if count_or_interval_present?
+        floor_date = dtstart
+      end
 
+      return enum_for(:each, floor_date: floor_date) unless block_given?
       context = Context.new(options, dtstart, tz)
-      context.rebuild(dtstart.year, dtstart.month)
+      context.rebuild(floor_date.year, floor_date.month)
 
       timeset = options[:timeset]
       count = options[:count]
@@ -59,13 +64,14 @@ module RRule
         generator = AllOccurrences.new(context)
       end
 
-      frequency = Frequency.for_options(options).new(context, filters, generator, timeset)
+      frequency = Frequency.for_options(options).new(context, filters, generator, timeset, start_date: floor_date)
 
       loop do
         return if frequency.current_date.year > max_year
 
         frequency.next_occurrences.each do |this_result|
           next if this_result < dtstart
+          next if floor_date.present? && this_result < floor_date
           return if options[:until] && this_result > options[:until]
           return if count && (count -= 1) < 0
           yield this_result unless exdate.include?(this_result)
@@ -92,8 +98,8 @@ module RRule
       @enumerator ||= to_enum
     end
 
-    def all_until(end_date: max_date, limit: nil)
-      limit ? take(limit) : take_while { |date| date <= end_date }
+    def all_until(start_date: nil, end_date: max_date, limit: nil)
+      limit ? take(limit) : each(floor_date: start_date).take_while { |date| date <= end_date }
     end
 
     def parse_options(rule)

--- a/lib/rrule/rule.rb
+++ b/lib/rrule/rule.rb
@@ -160,5 +160,9 @@ module RRule
 
       options
     end
+
+    def count_or_interval_present?
+      options[:count].present? || (options[:interval].present? && options[:interval] > 1)
+    end
   end
 end

--- a/spec/rule_spec.rb
+++ b/spec/rule_spec.rb
@@ -1979,7 +1979,7 @@ describe RRule::Rule do
       ])
     end
 
-    it 'returns the correct result with an rrule of FREQ=DAILY;COUNT=7 when the range extends beyond the end of the recurrence' do
+    it 'returns the correct result with an rrule of FREQ=DAILY;COUNT=7 when the range extends beyond the end of the recurrence (run out of COUNT before the range ends)' do
       rrule ='FREQ=DAILY;COUNT=7'
       dtstart = Time.parse('Thu Feb  6 16:00:00 PST 2014')
       timezone = 'America/Los_Angeles'

--- a/spec/rule_spec.rb
+++ b/spec/rule_spec.rb
@@ -2120,6 +2120,85 @@ describe RRule::Rule do
       end_time = Time.parse('Wed Aug 31 21:59:59 PDT 2016')
       expect(rule.between(start_time, end_time)).to eql([expected_instance])
     end
+
+
+    describe "iterating with a floor_date" do
+      describe "No COUNT or INTERVAL > 1" do
+        it "still limits to the given range" do
+          rrule = 'FREQ=DAILY'
+          dtstart = Time.parse('Tue Sep  2 06:00:00 PDT 1997')
+          timezone = 'America/New_York'
+
+          rrule = RRule::Rule.new(rrule, dtstart: dtstart, tzid: timezone)
+
+          start_time = Time.parse('Mon Sep  3 06:00:00 PDT 2018')
+          end_time   = Time.parse('Thu Sep  10 06:00:00 PDT 2018')
+
+          expect(rrule.between(start_time, end_time).take(3)).to match_array([
+            Time.parse('Tue Sep  3 06:00:00 PDT 2018'),
+            Time.parse('Wed Sep  4 06:00:00 PDT 2018'),
+            Time.parse('Thu Sep  5 06:00:00 PDT 2018')
+          ])
+        end
+      end
+
+      describe "COUNT present" do
+        it "still limits to the given range" do
+          rrule = 'FREQ=DAILY;COUNT=10'
+          dtstart = Time.parse('Tue Sep  2 06:00:00 PDT 1997')
+          timezone = 'America/New_York'
+
+          rrule = RRule::Rule.new(rrule, dtstart: dtstart, tzid: timezone)
+
+          start_time = Time.parse('Wed Sep  3 06:00:00 PDT 1997')
+          end_time   = Time.parse('Thu Sep  10 06:00:00 PDT 2018')
+
+          expect(rrule.between(start_time, end_time).take(3)).to match_array([
+            Time.parse('Tue Sep  3 06:00:00 PDT 1997'),
+            Time.parse('Wed Sep  4 06:00:00 PDT 1997'),
+            Time.parse('Thu Sep  5 06:00:00 PDT 1997'),
+          ])
+        end
+      end
+
+      describe "INTERVAL present" do
+        it "still limits to the given range" do
+          rrule = 'FREQ=DAILY;INTERVAL=10'
+          dtstart = Time.parse('Tue Sep  2 06:00:00 PDT 1997')
+          timezone = 'America/New_York'
+
+          rrule = RRule::Rule.new(rrule, dtstart: dtstart, tzid: timezone)
+
+          start_time = Time.parse('Wed Sep  3 06:00:00 PDT 1997')
+          end_time   = Time.parse('Thu Sep  30 06:00:00 PDT 2018')
+
+          expect(rrule.between(start_time, end_time).take(3)).to match_array([
+            Time.parse('Tue Sep 12 06:00:00 PDT 1997'),
+            Time.parse('Fri Sep 22 06:00:00 PDT 1997'),
+            Time.parse('Mon Oct 02 06:00:00 PDT 1997'),
+          ])
+        end
+      end
+
+      describe "INTERVAL AND COUNT present" do
+        it "still limits to the given range" do
+          rrule = 'FREQ=DAILY;INTERVAL=10;COUNT=5'
+          dtstart = Time.parse('Tue Sep  2 06:00:00 PDT 1997')
+          timezone = 'America/New_York'
+
+          rrule = RRule::Rule.new(rrule, dtstart: dtstart, tzid: timezone)
+
+          start_time = Time.parse('Wed Sep  3 06:00:00 PDT 1997')
+          end_time   = Time.parse('Thu Sep  30 06:00:00 PDT 2018')
+
+          expect(rrule.between(start_time, end_time).take(3)).to match_array([
+            Time.parse('Tue Sep 12 06:00:00 PDT 1997'),
+            Time.parse('Fri Sep 22 06:00:00 PDT 1997'),
+            Time.parse('Mon Oct 02 06:00:00 PDT 1997'),
+          ])
+        end
+      end
+    end
   end
 
   describe 'validation' do

--- a/spec/rule_spec.rb
+++ b/spec/rule_spec.rb
@@ -30,9 +30,9 @@ describe RRule::Rule do
     end
   end
 
-  describe "iterating with a floor_date" do
-    describe "No COUNT or INTERVAL > 1" do
-      it "uses the floor_date provided when iterating" do
+  describe 'iterating with a floor_date' do
+    describe 'No COUNT or INTERVAL > 1' do
+      it 'uses the floor_date provided when iterating' do
         rrule = 'FREQ=DAILY'
         dtstart = Time.parse('Tue Sep  2 06:00:00 PDT 1997')
         timezone = 'America/New_York'
@@ -49,8 +49,8 @@ describe RRule::Rule do
       end
     end
 
-    describe "COUNT present" do
-      it "starts at dtstart when iterating" do
+    describe 'COUNT present' do
+      it 'starts at dtstart when iterating' do
         rrule = 'FREQ=DAILY;COUNT=10'
         dtstart = Time.parse('Tue Sep  2 06:00:00 PDT 1997')
         timezone = 'America/New_York'
@@ -67,8 +67,8 @@ describe RRule::Rule do
       end
     end
 
-    describe "INTERVAL present" do
-      it "starts at dtstart when iterating" do
+    describe 'INTERVAL present' do
+      it 'starts at dtstart when iterating' do
         rrule = 'FREQ=DAILY;INTERVAL=10'
         dtstart = Time.parse('Tue Sep  2 06:00:00 PDT 1997')
         timezone = 'America/New_York'
@@ -85,8 +85,8 @@ describe RRule::Rule do
       end
     end
 
-    describe "INTERVAL AND COUNT present" do
-      it "starts at dtstart when iterating" do
+    describe 'INTERVAL AND COUNT present' do
+      it 'starts at dtstart when iterating' do
         rrule = 'FREQ=DAILY;INTERVAL=10;COUNT=5'
         dtstart = Time.parse('Tue Sep  2 06:00:00 PDT 1997')
         timezone = 'America/New_York'
@@ -1789,6 +1789,25 @@ describe RRule::Rule do
   end
 
   describe '#between' do
+    it 'returns the correct result with an rrule of FREQ=WEEKLY;BYSECOND=59;BYMINUTE=59;BYHOUR=23;WKST=SU' do
+      rrule = 'FREQ=WEEKLY;BYSECOND=59;BYMINUTE=59;BYHOUR=23;WKST=SU'
+      dtstart = DateTime.parse('2018-02-04 04:00:00 +1000')
+      timezone = 'Brisbane'
+
+      rrule = RRule::Rule.new(rrule, dtstart: dtstart, tzid: timezone)
+      expect(rrule.between(Time.parse('Sun, 08 Apr 2018 00:00:00 +0000'), Time.parse('Fri, 08 Jun 2018 23:59:59 +0000'))).to match_array([
+        Time.parse('Sun, 08 Apr 2018 23:59:59 +1000'),
+        Time.parse('Sun, 15 Apr 2018 23:59:59 +1000'),
+        Time.parse('Sun, 22 Apr 2018 23:59:59 +1000'),
+        Time.parse('Sun, 29 Apr 2018 23:59:59 +1000'),
+        Time.parse('Sun, 06 May 2018 23:59:59 +1000'),
+        Time.parse('Sun, 13 May 2018 23:59:59 +1000'),
+        Time.parse('Sun, 20 May 2018 23:59:59 +1000'),
+        Time.parse('Sun, 27 May 2018 23:59:59 +1000'),
+        Time.parse('Sun, 03 Jun 2018 23:59:59 +1000'),
+      ])
+    end
+
     it 'returns the correct result with an rrule of FREQ=DAILY;INTERVAL=2' do
       rrule = 'FREQ=DAILY;INTERVAL=2'
       dtstart = Time.parse('Tue Sep  2 06:00:00 PDT 1997')
@@ -2076,7 +2095,7 @@ describe RRule::Rule do
       expect(rrule.all).to match_array([
         Time.parse('Tue Sep  2 06:00:00 PST 1997'),
         Time.parse('Wed Sep  3 06:00:00 PST 1997'),
-        Time.parse('Thu Sep  4 06:00:00 PST 1997"'),
+        Time.parse('Thu Sep  4 06:00:00 PST 1997'),
         Time.parse('Sat Sep  6 06:00:00 PST 1997'),
         Time.parse('Sun Sep  7 06:00:00 PST 1997'),
         Time.parse('Tue Sep  9 06:00:00 PST 1997'),
@@ -2122,9 +2141,9 @@ describe RRule::Rule do
     end
 
 
-    describe "iterating with a floor_date" do
-      describe "No COUNT or INTERVAL > 1" do
-        it "still limits to the given range" do
+    describe 'iterating with a floor_date' do
+      describe 'No COUNT or INTERVAL > 1' do
+        it 'still limits to the given range' do
           rrule = 'FREQ=DAILY'
           dtstart = Time.parse('Tue Sep  2 06:00:00 PDT 1997')
           timezone = 'America/New_York'
@@ -2142,8 +2161,8 @@ describe RRule::Rule do
         end
       end
 
-      describe "COUNT present" do
-        it "still limits to the given range" do
+      describe 'COUNT present' do
+        it 'still limits to the given range' do
           rrule = 'FREQ=DAILY;COUNT=10'
           dtstart = Time.parse('Tue Sep  2 06:00:00 PDT 1997')
           timezone = 'America/New_York'
@@ -2161,8 +2180,8 @@ describe RRule::Rule do
         end
       end
 
-      describe "INTERVAL present" do
-        it "still limits to the given range" do
+      describe 'INTERVAL present' do
+        it 'still limits to the given range' do
           rrule = 'FREQ=DAILY;INTERVAL=10'
           dtstart = Time.parse('Tue Sep  2 06:00:00 PDT 1997')
           timezone = 'America/New_York'
@@ -2180,8 +2199,8 @@ describe RRule::Rule do
         end
       end
 
-      describe "INTERVAL AND COUNT present" do
-        it "still limits to the given range" do
+      describe 'INTERVAL AND COUNT present' do
+        it 'still limits to the given range' do
           rrule = 'FREQ=DAILY;INTERVAL=10;COUNT=5'
           dtstart = Time.parse('Tue Sep  2 06:00:00 PDT 1997')
           timezone = 'America/New_York'

--- a/spec/rule_spec.rb
+++ b/spec/rule_spec.rb
@@ -30,6 +30,80 @@ describe RRule::Rule do
     end
   end
 
+  describe "iterating with a floor_date" do
+    describe "No COUNT or INTERVAL > 1" do
+      it "uses the floor_date provided when iterating" do
+        rrule = 'FREQ=DAILY'
+        dtstart = Time.parse('Tue Sep  2 06:00:00 PDT 1997')
+        timezone = 'America/New_York'
+
+        rrule = RRule::Rule.new(rrule, dtstart: dtstart, tzid: timezone)
+
+        floor_date = Time.parse('Mon Sep  3 06:00:00 PDT 2018')
+
+        expect(rrule.each(floor_date: floor_date).take(3)).to match_array([
+          Time.parse('Tue Sep  3 06:00:00 PDT 2018'),
+          Time.parse('Wed Sep  4 06:00:00 PDT 2018'),
+          Time.parse('Thu Sep  5 06:00:00 PDT 2018')
+        ])
+      end
+    end
+
+    describe "COUNT present" do
+      it "starts at dtstart when iterating" do
+        rrule = 'FREQ=DAILY;COUNT=10'
+        dtstart = Time.parse('Tue Sep  2 06:00:00 PDT 1997')
+        timezone = 'America/New_York'
+
+        rrule = RRule::Rule.new(rrule, dtstart: dtstart, tzid: timezone)
+
+        floor_date = Time.parse('Mon Sep  3 06:00:00 PDT 2018')
+
+        expect(rrule.each(floor_date: floor_date).take(3)).to match_array([
+          Time.parse('Tue Sep  2 06:00:00 PDT 1997'),
+          Time.parse('Wed Sep  3 06:00:00 PDT 1997'),
+          Time.parse('Thu Sep  4 06:00:00 PDT 1997'),
+        ])
+      end
+    end
+
+    describe "INTERVAL present" do
+      it "starts at dtstart when iterating" do
+        rrule = 'FREQ=DAILY;INTERVAL=10'
+        dtstart = Time.parse('Tue Sep  2 06:00:00 PDT 1997')
+        timezone = 'America/New_York'
+
+        rrule = RRule::Rule.new(rrule, dtstart: dtstart, tzid: timezone)
+
+        floor_date = Time.parse('Mon Sep  3 06:00:00 PDT 2018')
+
+        expect(rrule.each(floor_date: floor_date).take(3)).to match_array([
+          Time.parse('Tue Sep  2 06:00:00 PDT 1997'),
+          Time.parse('Fri Sep 12 06:00:00 PDT 1997'),
+          Time.parse('Mon Sep 22 06:00:00 PDT 1997'),
+        ])
+      end
+    end
+
+    describe "INTERVAL AND COUNT present" do
+      it "starts at dtstart when iterating" do
+        rrule = 'FREQ=DAILY;INTERVAL=10;COUNT=5'
+        dtstart = Time.parse('Tue Sep  2 06:00:00 PDT 1997')
+        timezone = 'America/New_York'
+
+        rrule = RRule::Rule.new(rrule, dtstart: dtstart, tzid: timezone)
+
+        floor_date = Time.parse('Mon Sep  3 06:00:00 PDT 2018')
+
+        expect(rrule.each(floor_date: floor_date).take(3)).to match_array([
+          Time.parse('Tue Sep  2 06:00:00 PDT 1997'),
+          Time.parse('Fri Sep 12 06:00:00 PDT 1997'),
+          Time.parse('Mon Sep 22 06:00:00 PDT 1997'),
+        ])
+      end
+    end
+  end
+
   describe '#all' do
     it 'returns the correct result with an rrule of FREQ=DAILY;COUNT=10' do
       rrule = 'FREQ=DAILY;COUNT=10'


### PR DESCRIPTION
Allow a floor_date to be passed to `RRule#each`, for performance
* Previously, methods like `between` would enumerate from `dtstart`
  onward, which lead to an O(n) problem (where `n` is the length of
  time between `dtstart` and `between(start_date`)). This allows a
  floor date to be passed, which is used to build the context for the
  `Enumerable`, allows us to floor the Enumerator as needed
* However, this performance improvement can only be used if the RRULE
  does not have a COUNT or INTERVAL option, because both of those
  options require us to start iterating from the `dtstart` in order to
  return the correct results
* Added some basic tests of how the Enumerator handles the
  `floor_date`


---------
Below are 2 runs of `scripts/benchmark.rb`, the first is this PR, the second is the current version (0.3.0)

```
$ git log -1 --pretty=oneline
a678a782070168fd2090b69968153d9a027bcd2e Allow a floor_date to be passed to `RRule#each`, for performance
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 12:01:00
$ ruby scripts/benchmark.rb
Benchmarking rules in version 0.3.0: 1000 expansions over one month
                           user     system      total        real
FREQ=WEEKLY            0.270000   0.010000   0.280000 (  0.277578)
FREQ=WEEKLY;BYDAY=WE   0.430000   0.000000   0.430000 (  0.429060)

---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 12:01:10
$ git checkout 19e3e8d67dcf4810bbe65c20c851b50fbe0bce35
$ git log -1 --pretty=oneline
19e3e8d67dcf4810bbe65c20c851b50fbe0bce35 Merge pull request #9 from square/rmitchell/bump-version
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 12:01:30
$ ruby scripts/benchmark.rb
Benchmarking rules in version 0.3.0: 1000 expansions over one month
                           user     system      total        real
FREQ=WEEKLY            7.150000   0.040000   7.190000 (  7.210978)
FREQ=WEEKLY;BYDAY=WE  12.440000   0.080000  12.520000 ( 12.564897)
```