### PR TITLE
Raise InvalidRRule when FREQ missing/invalid

### DIFF
--- a/lib/rrule/frequencies/frequency.rb
+++ b/lib/rrule/frequencies/frequency.rb
@@ -50,6 +50,8 @@ module RRule
         Monthly
       when 'YEARLY'
         Yearly
+      else
+        raise InvalidRRule, "Valid FREQ value is required"
       end
     end
 

--- a/lib/rrule/rule.rb
+++ b/lib/rrule/rule.rb
@@ -9,6 +9,7 @@ module RRule
       @tz = tzid
       @exdate = exdate
       @options = parse_options(rrule)
+      @frequency_type = Frequency.for_options(options)
       @max_year = max_year || 9999
       @max_date = DateTime.new(@max_year)
     end
@@ -59,7 +60,7 @@ module RRule
         generator = AllOccurrences.new(context)
       end
 
-      frequency = Frequency.for_options(options).new(context, filters, generator, timeset)
+      frequency = frequency_type.new(context, filters, generator, timeset)
 
       loop do
         return if frequency.current_date.year > max_year
@@ -79,7 +80,7 @@ module RRule
 
     private
 
-    attr_reader :options, :max_year, :max_date
+    attr_reader :options, :max_year, :max_date, :frequency_type
 
     def floor_to_seconds(date)
       # This removes all sub-second and floors it to the second level.

--- a/spec/rule_spec.rb
+++ b/spec/rule_spec.rb
@@ -2049,6 +2049,14 @@ describe RRule::Rule do
   end
 
   describe 'validation' do
+    it 'raises RRule::InvalidRRule if FREQ is not provided' do
+      expect { RRule::Rule.new('') }.to raise_error(RRule::InvalidRRule)
+      expect { RRule::Rule.new('FREQ=') }.to raise_error(RRule::InvalidRRule)
+      expect { RRule::Rule.new('FREQ=FOO') }.to raise_error(RRule::InvalidRRule)
+      expect { RRule::Rule.new('COUNT=1') }.to raise_error(RRule::InvalidRRule)
+      expect { RRule::Rule.new('FREQ=FOO;COUNT=1') }.to raise_error(RRule::InvalidRRule)
+    end
+
     it 'raises RRule::InvalidRRule if INTERVAL is not a positive integer' do
       dtstart = Time.parse('Tue Sep  2 06:00:00 PDT 1997')
       timezone = 'America/New_York'


### PR DESCRIPTION
Before this PR the following code provides no error and appears to be a valid rule:

```ruby
RRule::Rule.new('')
```

Trying to use this rule will result in the following error:

```
NoMethodError: undefined method `new' for nil:NilClass
from /gems/rrule-0.3.1/lib/rrule/rule.rb:62:in `each'
```

The presence and validity of FREQ is not being checked before `Rule#each`. This PR moves `Frequency.for_options` into the rule initializer, which has been modified to raise an `InvalidRRule` error if a valid frequency is not found.

I also have a branch where [missing FREQ values are treated as non-recurring rules](https://github.com/square/ruby-rrule/compare/master...GhostGroup:blank-rule-no-recurrence) in case that is preferred. The RFC states the field is required, but I have seen some blank RRULE values for single occurrence ical events. This branch would provide pass-thru support for blank RRULEs, simplifying downstream integration.

I don't have a strong preference between the approaches. I do think this gem needs more validation in general, and may need a strict mode flag to control it so that invalid parts of mostly-valid RRULEs can be safely ignored if desired. Example: unknown FREQ would be treated as non-recurring, negative COUNT values ignored, etc. I would be happy to help with this but would like to get feedback on what the maintainers intend.