### PR TITLE
Fix context memoization

### DIFF
--- a/lib/rrule/context.rb
+++ b/lib/rrule/context.rb
@@ -39,10 +39,10 @@ module RRule
             end
           end
         end
-
-        @last_year = year
-        @last_month = month
       end
+
+      @last_year = year
+      @last_month = month
     end
 
     def year_length_in_days


### PR DESCRIPTION
For any rrules without byweekday rules, the context is not getting `@last_year` and `@last_month` set/updated, so the context keeps calling `reset_year` because `year` is always not `last_year`.  This unnecessarily clears the memoization values more frequently.

Simple fix, looks like the instance variables were just placed in the wrong scope.

Might result in (very?) slight performance improvements?