### PR TITLE
Fix memoization variable for negative_week_number_by_day_of_year

### DIFF
--- a/lib/rrule/context.rb
+++ b/lib/rrule/context.rb
@@ -82,7 +82,7 @@ module RRule
     end
 
     def negative_week_number_by_day_of_year
-      @negative_month_day_by_day_of_year ||= days_in_year.map { |day| day.cweek - Date.new(day.cwyear, 12, 28).cweek - 1 }
+      @negative_week_number_by_day_of_year ||= days_in_year.map { |day| day.cweek - Date.new(day.cwyear, 12, 28).cweek - 1 }
     end
 
     def elapsed_days_in_year_by_month


### PR DESCRIPTION
`negative_week_number_by_day_of_year` method was clobbering `@ negative_month_day_by_day_of_year `.  Doesn't appear to have had any effect on the tests though, so it may not have been "technically" broken, but this PR fixes the typo.