### PR TITLE
Fix bug with simple weekly frequency when ENV['TZ'] does not match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Change Log
 ==========
 
+Version 0.4.1 *(2018-11-28)*
+----------------------------
+Fix bug in SimpleWeekly when ENV['TZ'] was not equal to time zone of rrule
+
+
 Version 0.1.0 *(2017-06-06)*
 ----------------------------
 

--- a/lib/rrule/rule.rb
+++ b/lib/rrule/rule.rb
@@ -5,8 +5,8 @@ module RRule
     attr_reader :dtstart, :tz, :exdate
 
     def initialize(rrule, dtstart: Time.now, tzid: 'UTC', exdate: [], max_year: nil)
-      @dtstart = floor_to_seconds(dtstart).in_time_zone(tzid)
       @tz = tzid
+      @dtstart = floor_to_seconds_in_timezone(dtstart)
       @exdate = exdate
       @options = parse_options(rrule)
       @frequency_type = Frequency.for_options(options)
@@ -19,8 +19,8 @@ module RRule
     end
 
     def between(start_date, end_date, limit: nil)
-      floored_start_date = floor_to_seconds(start_date)
-      floored_end_date = floor_to_seconds(end_date)
+      floored_start_date = floor_to_seconds_in_timezone(start_date)
+      floored_end_date = floor_to_seconds_in_timezone(end_date)
       all_until(start_date: floored_start_date, end_date: floored_end_date, limit: limit).reject { |instance| instance < floored_start_date }
     end
 
@@ -88,11 +88,11 @@ module RRule
 
     attr_reader :options, :max_year, :max_date, :frequency_type
 
-    def floor_to_seconds(date)
+    def floor_to_seconds_in_timezone(date)
       # This removes all sub-second and floors it to the second level.
       # Sub-second level calculations breaks a lot of assumptions in this
       # library and rounding it may also cause unexpected inequalities.
-      Time.at(date.to_i)
+      Time.at(date.to_i).in_time_zone(tz)
     end
 
     def enumerator

--- a/rrule.gemspec
+++ b/rrule.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'rrule'
-  s.version = '0.4.0'
+  s.version = '0.4.1'
   s.date = '2018-04-24'
   s.summary = 'RRule expansion'
   s.description = 'A gem for expanding dates according to the RRule specification'

--- a/spec/rule_spec.rb
+++ b/spec/rule_spec.rb
@@ -1789,6 +1789,24 @@ describe RRule::Rule do
   end
 
   describe '#between' do
+    context 'server env timezone is different from the passed timezone' do
+      around do |example|
+        old_tz = ENV['TZ']
+        ENV['TZ'] = 'UTC'
+        example.run
+        ENV['TZ'] = old_tz
+      end
+
+      it 'works when the day in the given timezone is different from the day in the server timezone' do
+        # any time from 17:00 to 23:59:59 broke old code, test all hours of the day
+        0.upto(23) do |hour|
+          dtstart = Time.new(2018, 7, 1, hour, 0, 0, '-07:00')
+          rrule = RRule::Rule.new('FREQ=WEEKLY', dtstart: dtstart, tzid: 'America/Los_Angeles')
+          expect(rrule.between(dtstart, dtstart + 1.second)).to eq([dtstart])
+        end
+      end
+    end
+
     it 'returns the correct result with an rrule of FREQ=WEEKLY;BYSECOND=59;BYMINUTE=59;BYHOUR=23;WKST=SU' do
       rrule = 'FREQ=WEEKLY;BYSECOND=59;BYMINUTE=59;BYHOUR=23;WKST=SU'
       dtstart = DateTime.parse('2018-02-04 04:00:00 +1000')


### PR DESCRIPTION
date_start timezone

When comparing days of the week, it's important that both the
`@current_date` and the `date_start` are in the same timezone. However,
this wasn't the case, leading to the first occurrence not being returned
if the _day of week_ was different between the ENV['TZ'] and the
date_start timezone.