### PR TITLE
Add gemspec metadata

### DIFF
--- a/rrule.gemspec
+++ b/rrule.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.files = `git ls-files`.split($/)
   s.test_files = s.files.grep(%r{^(test|spec|features)/})
   s.require_paths = ['lib']
-  s.homepage = 'http://rubygems.org/gems/rrule'
+  s.homepage = 'https://rubygems.org/gems/rrule'
 
   # Since Ruby 1.9.2, Time implementation uses a signed 63 bit integer, Bignum
   # or Rational. This enables Time to finally work with years after 2038 which

--- a/rrule.gemspec
+++ b/rrule.gemspec
@@ -10,6 +10,12 @@ Gem::Specification.new do |s|
   s.test_files = s.files.grep(%r{^(test|spec|features)/})
   s.require_paths = ['lib']
   s.homepage = 'https://rubygems.org/gems/rrule'
+  s.metadata = {
+    'homepage' => 'https://rubygems.org/gems/rrule',
+    'source_code_uri' => 'https://github.com/square/ruby-rrule',
+    'bug_tracker_uri' => 'https://github.com/square/ruby-rrule/issues',
+    'changelog_uri' => 'https://github.com/square/ruby-rrule/blob/master/CHANGELOG.md'
+  }
 
   # Since Ruby 1.9.2, Time implementation uses a signed 63 bit integer, Bignum
   # or Rational. This enables Time to finally work with years after 2038 which


### PR DESCRIPTION
Adds [gemspec metadata](https://guides.rubygems.org/specification-reference/#metadata).

Makes it easier to find the source code from the gem (both for humans and automated tooling).