### PR TITLE
Fix spec test failing due to insufficient timezone data

### DIFF
--- a/spec/rule_spec.rb
+++ b/spec/rule_spec.rb
@@ -1677,18 +1677,18 @@ describe RRule::Rule do
       ])
     end
 
-    # Ruby's Time class only properly handles years up to 2038, and so gives an incorrect
-    # offset for the last two occurrences here.
-    xit 'returns the correct result with an rrule of FREQ=YEARLY;COUNT=3;INTERVAL=100' do
+    # At time of writing IANA timezone data was only available up until the year 2050
+    # hence we perform these calculations in UTC in order to avoid problems
+    # with periods of daylight savings time
+    it 'returns the correct result with an rrule of FREQ=YEARLY;COUNT=3;INTERVAL=100' do
       rrule = 'FREQ=YEARLY;COUNT=3;INTERVAL=100'
-      dtstart = Time.parse('Tue Sep  2 09:00:00 PDT 1997')
-      timezone = 'America/Los_Angeles'
+      dtstart = Time.parse('Tue Sep  2 09:00:00 UTC 1997')
 
-      rrule = RRule::Rule.new(rrule, dtstart: dtstart, tzid: timezone)
+      rrule = RRule::Rule.new(rrule, dtstart: dtstart)
       expect(rrule.all).to match_array([
-        Time.parse('Tue Sep  2 09:00:00 PDT 1997'),
-        Time.parse('Mon Sep  2 09:00:00 PDT 2097'),
-        Time.parse('Sat Sep  2 09:00:00 PDT 2197'),
+        Time.parse('Tue Sep  2 09:00:00 UTC 1997'),
+        Time.parse('Mon Sep  2 09:00:00 UTC 2097'),
+        Time.parse('Sat Sep  2 09:00:00 UTC 2197'),
       ])
     end
 


### PR DESCRIPTION
Currently the [IANA timezone data](https://www.iana.org/time-zones)
for California is only available up until the year 2050, ending on

```text
TZ="America/Los_Angeles"
2047-11-03  01  -08 PST
2048-03-08  03  -07 PDT 1
2048-11-01  01  -08 PST
2049-03-14  03  -07 PDT 1
2049-11-07  01  -08 PST
```

i.e. all timestamps after 2049-11-07 will be provided in PST (not PDT)
independent of date. Spec tests which go past this date do not fail
not due to lack of numerical accuracy, but rather due to insufficient
knowledge about the future evolution of timezones, and should
therefore be rewritten to use UTC.