### PR TITLE
adjusts parser to ignore `RRULE:` prefix

### DIFF
--- a/lib/rrule/rule.rb
+++ b/lib/rrule/rule.rb
@@ -95,7 +95,8 @@ module RRule
     def parse_options(rule)
       options = { interval: 1, wkst: 1 }
 
-      params = rule.split(';')
+      # Remove RRULE: prefix to prevent parsing options incorrectly.
+      params = rule.delete_prefix('RRULE:').split(';')
       params.each do |param|
         option, value = param.split('=')
 

--- a/spec/rule_spec.rb
+++ b/spec/rule_spec.rb
@@ -2504,4 +2504,16 @@ describe RRule::Rule do
       expect { RRule::Rule.new('FREQ=DAILY;COUNT=-1', dtstart: dtstart, tzid: timezone) }.to raise_error(RRule::InvalidRRule)
     end
   end
+
+  it "correctly parses rule strings with an 'RRULE:' prefix" do
+    rrule = 'RRULE:INTERVAL=2;FREQ=DAILY;COUNT=10'
+    dtstart = Time.parse('Tue Sep  2 06:00:00 PDT 1997')
+    timezone = 'America/New_York'
+
+    rrule = RRule::Rule.new(rrule, dtstart: dtstart, tzid: timezone)
+
+    expect(rrule.next).to eql Time.parse('Tue Sep  2 06:00:00 PDT 1997')
+    expect(rrule.next).to eql Time.parse('Wed Sep  4 06:00:00 PDT 1997')
+    expect(rrule.next).to eql Time.parse('Thu Sep  6 06:00:00 PDT 1997')
+  end
 end


### PR DESCRIPTION
This commit adjusts the rule parsing step so that it will ignore an
  `RRULE:` prefix when it is present.

The reason for this change is that many 3rd party libraries output
  RRULE strings with this prefix, which makes sense given the
  [spec](https://icalendar.org/iCalendar-RFC-5545/3-8-5-3-recurrence-rule.html).

Previously, if you had something like this:

```ruby
rrule = "RRULE:INTERVAL=2;FREQ=DAILY;COUNT=1"
```

the parser would ignore the `INTERVAL` param and so you'd end up with a
  daily occurrence as opposed to the desired every other day occurence.