### PR TITLE
config(deps): allow any activesupport >= 2.3

### DIFF
--- a/rrule.gemspec
+++ b/rrule.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |s|
   }
 
   s.required_ruby_version = '>= 2.6.0'
-  s.add_runtime_dependency 'activesupport', '>= 2.3', '< 7'
+  s.add_runtime_dependency 'activesupport', '>= 2.3'
   s.add_development_dependency 'appraisal'
 end


### PR DESCRIPTION
The version was capped to be less than 7.0, but there is nothing specifically known about 7 or any future version that would break this gem. This change allows for any version of activesupport so it's less defensive about the future.

This is in preparation for Rails 7.0 which will bump the activesupport version.