### PR TITLE
Rule#between didn't work when `limit` was provided

### DIFF
--- a/lib/rrule/rule.rb
+++ b/lib/rrule/rule.rb
@@ -89,7 +89,14 @@ module RRule
     end
 
     def all_until(start_date: nil, end_date: max_date, limit: nil)
-      limit ? take(limit) : each(floor_date: start_date).take_while { |date| date <= end_date }
+      count = 0
+      each(floor_date: start_date).take_while do |date|
+        if limit
+          date <= end_date && (count += 1) <= limit
+        else
+          date <= end_date
+        end
+      end
     end
 
     def parse_options(rule)

--- a/spec/rule_spec.rb
+++ b/spec/rule_spec.rb
@@ -1848,6 +1848,44 @@ describe RRule::Rule do
       ])
     end
 
+    it 'returns the correct result with an rrule of FREQ=WEEKLY;BYSECOND=59;BYMINUTE=59;BYHOUR=23;WKST=SU starting beyond the beginning of the result' do
+      rrule = 'FREQ=WEEKLY;BYSECOND=59;BYMINUTE=59;BYHOUR=23;WKST=SU'
+      dtstart = Time.parse('2018-02-04 04:00:00 +1000')
+      timezone = 'Brisbane'
+
+      rrule = RRule::Rule.new(rrule, dtstart: dtstart, tzid: timezone)
+      expect(rrule.between(Time.parse('Sun, 13 May 2018 23:59:59 +1000'), Time.parse('Fri, 08 Jun 2018 23:59:59 +0000'))).to match_array([
+        Time.parse('Sun, 13 May 2018 23:59:59 +1000'),
+        Time.parse('Sun, 20 May 2018 23:59:59 +1000'),
+        Time.parse('Sun, 27 May 2018 23:59:59 +1000'),
+        Time.parse('Sun, 03 Jun 2018 23:59:59 +1000'),
+      ])
+    end
+
+    it 'returns the correct result with an rrule of FREQ=WEEKLY;BYSECOND=59;BYMINUTE=59;BYHOUR=23;WKST=SU with a limit' do
+      rrule = 'FREQ=WEEKLY;BYSECOND=59;BYMINUTE=59;BYHOUR=23;WKST=SU'
+      dtstart = Time.parse('2018-02-04 04:00:00 +1000')
+      timezone = 'Brisbane'
+
+      rrule = RRule::Rule.new(rrule, dtstart: dtstart, tzid: timezone)
+      expect(rrule.between(Time.parse('Sun, 08 Apr 2018 00:00:00 +0000'), Time.parse('Fri, 08 Jun 2018 23:59:59 +0000'), limit: 2)).to match_array([
+        Time.parse('Sun, 08 Apr 2018 23:59:59 +1000'),
+        Time.parse('Sun, 15 Apr 2018 23:59:59 +1000'),
+      ])
+    end
+
+    it 'returns the correct result with an rrule of FREQ=WEEKLY;BYSECOND=59;BYMINUTE=59;BYHOUR=23;WKST=SU starting beyond the beginning of the result with a limit' do
+      rrule = 'FREQ=WEEKLY;BYSECOND=59;BYMINUTE=59;BYHOUR=23;WKST=SU'
+      dtstart = Time.parse('2018-02-04 04:00:00 +1000')
+      timezone = 'Brisbane'
+
+      rrule = RRule::Rule.new(rrule, dtstart: dtstart, tzid: timezone)
+      expect(rrule.between(Time.parse('Sun, 13 May 2018 23:59:59 +1000'), Time.parse('Fri, 08 Jun 2018 23:59:59 +0000'), limit: 2)).to match_array([
+        Time.parse('Sun, 13 May 2018 23:59:59 +1000'),
+        Time.parse('Sun, 20 May 2018 23:59:59 +1000'),
+      ])
+    end
+
     it 'returns the correct result with an rrule of FREQ=DAILY;INTERVAL=2' do
       rrule = 'FREQ=DAILY;INTERVAL=2'
       dtstart = Time.parse('Tue Sep  2 06:00:00 PDT 1997')


### PR DESCRIPTION
This fix allows the `limit` parameter to work properly when used with `Rule#between`.