### PR TITLE
Add support for bymonthday

### DIFF
--- a/lib/rrule/humanizer.rb
+++ b/lib/rrule/humanizer.rb
@@ -188,6 +188,11 @@ module RRule
         add list(bynweekday_option, method(:weekdaytext), 'and')
       end
 
+      def _bymonthday
+        add 'on the'
+        add list (bymonthday_option.map { |o| nth(o) }), :to_s, 'and'
+      end
+
       def _byhour
         add 'at'
         add list byhour_option, :to_s, 'and'

--- a/spec/rule_spec.rb
+++ b/spec/rule_spec.rb
@@ -2645,6 +2645,12 @@ describe RRule::Rule do
 
       it { expect(rrule.humanize).to eq 'every month on the 1st Monday and last Friday for 7 times' }
     end
+
+    context 'every month on the 14th' do
+      let(:rule) { 'FREQ=MONTHLY;INTERVAL=1;BYMONTHDAY=14,15' }
+
+      it { expect(rrule.humanize).to eq 'every month on the 14th and 15th' }
+    end
   end
 
   describe '#is_finite?' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,6 +21,9 @@ RSpec.configure do |config|
     # `true` in RSpec 4.
     mocks.verify_partial_doubles = true
   end
+
+  # Focus with fit, fdescribe, and fcontext
+  config.filter_run_when_matching :focus
 end
 
 Time.zone = 'America/Los_Angeles'


### PR DESCRIPTION
This `FREQ=MONTHLY;INTERVAL=1;BYMONTHDAY=14,15` seems to be a valid ICAL RRule, but this gem is not parsing it correctly resulting in this error:

```ruby
rr = RRule.parse("FREQ=MONTHLY;INTERVAL=1;BYMONTHDAY=14") # => #<RRule::Rule:0x0000ffff6fc049e0 ...>
rr.humanize
/usr/local/bundle/gems/rrule-0.6.0/lib/rrule/humanizer.rb:49:in `method_missing': undefined local variable or method `_bymonthday' for #<RRule::Humanizer:0x0000ffff6fcaba88> (NameError)
Did you mean?  _bymonth
```

This PR adds support for humanizing the above RRule string.