### PR TITLE
Pick and choose specific ActiveSupport extensions instead of pulling in the whole thing

### DIFF
--- a/lib/rrule.rb
+++ b/lib/rrule.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
-require 'active_support/all'
+require 'active_support'
+require 'active_support/core_ext/time'
+require 'active_support/core_ext/object/blank'
+require 'active_support/core_ext/integer/time'
+require 'active_support/core_ext/array/wrap'
 
 module RRule
   autoload :Rule, 'rrule/rule'


### PR DESCRIPTION
I ran across this when doing some profiling of an app that uses this library inside an AWS Lambda function, where Rails isn't loaded by default and the response time is a bit more sensitive. I profiled the gem load times using [bumbler](https://github.com/nevir/Bumbler), and dug in when I saw that `rrule-ruby` was one of the longer times (around 500ms). That `activesupport/all` require is the big one, and it seems somewhat unnecessary since only a few extensions are actually used here.

This PR replaces that big require with just the specific items used in the lib/tests, which shouldn't present any major changes to downstream users but will make the load time a little quicker when used outside of a Rails app, or really anyplace that doesn't load all of Active Support by default. I'm working on deploying to get a better read on the exact load time savings, and will update with a comment when I have that.

This is a terrific library, btw - thanks for opening it up and maintaining it!