### PR TITLE
Update version of actions/cache in Github workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
         run: yes | gem update --system --force
       - name: 'Update Bundler'
         run: gem install bundler
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: vendor/bundle
           key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
         run: yes | gem update --system --force
       - name: 'Update Bundler'
         run: gem install bundler
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: vendor/bundle
           key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}

--- a/Appraisals
+++ b/Appraisals
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-appraise 'activesupport-6_1' do
-  gem 'activesupport', '~> 6.1'
-end
-
 appraise 'activesupport-7_0' do
   gem 'activesupport', '~> 7.0'
 end
@@ -11,3 +7,13 @@ end
 appraise 'activesupport-7_1' do
   gem 'activesupport', '~> 7.1'
 end
+
+appraise 'activesupport-7_2' do
+  gem 'activesupport', '~> 7.2'
+end
+
+
+appraise 'activesupport-8_0' do
+  gem 'activesupport', '~> 8.0'
+end
+


### PR DESCRIPTION
Versions older than V3 are now deprecated and won't run: https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down