### PR TITLE
Add support for `yearly` event with `bymonthday`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ Gemfile.lock
 *.sublime-workspace
 .ruby-version
 gemfiles/*.lock
+.idea

--- a/lib/rrule/rule.rb
+++ b/lib/rrule/rule.rb
@@ -168,13 +168,13 @@ module RRule
         end
       end
 
-      unless options[:byweekno] || options[:byyearday] || options[:bymonthday] || options[:byweekday]
+      unless options[:byweekno] || options[:byyearday] || options[:byweekday]
         case options[:freq]
         when 'YEARLY'
-          options[:bymonth] = [dtstart.month] unless options[:bymonth]
-          options[:bymonthday] = [dtstart.day]
+          options[:bymonth] = [dtstart.month] unless options[:bymonth] || (options[:bymonthday] && options[:count])
+          options[:bymonthday] = [dtstart.day] unless options[:bymonthday]
         when 'MONTHLY'
-          options[:bymonthday] = [dtstart.day]
+          options[:bymonthday] = [dtstart.day] unless options[:bymonthday]
         when 'WEEKLY'
           options[:simple_weekly] = true
           options[:byweekday] = [Weekday.new(dtstart.wday)]

--- a/spec/rule_spec.rb
+++ b/spec/rule_spec.rb
@@ -2183,6 +2183,20 @@ describe RRule::Rule do
       ])
     end
 
+    it 'returns the correct result with an rrule of FREQ=YEARLY;BYMONTHDAY=25' do
+      rrule = 'FREQ=YEARLY;BYMONTHDAY=25'
+      dtstart = Time.parse('Mon Apr 1 19:00:00 PDT 2024')
+      timezone = 'America/Los_Angeles'
+
+      rrule = RRule::Rule.new(rrule, dtstart: dtstart, tzid: timezone)
+      expect(rrule.between(Time.parse('Thu Mar 13 06:00:00 PST 2024'), Time.parse('Thu Mar 25 06:00:00 PST 2028'))).to match_array([
+                                               Time.parse('Mon Apr 25 19:00:00 PDT 2024'),
+                                               Time.parse('Mon Apr 25 19:00:00 PDT 2025'),
+                                               Time.parse('Mon Apr 25 19:00:00 PDT 2026'),
+                                               Time.parse('Mon Apr 25 19:00:00 PDT 2027'),
+                                             ])
+    end
+
     it 'returns the correct result with an rrule of FREQ=YEARLY;BYMONTH=3;BYDAY=TH' do
       rrule = 'FREQ=YEARLY;BYMONTH=3;BYDAY=TH'
       dtstart = Time.parse('Thu Mar 13 06:00:00 PST 1997')


### PR DESCRIPTION
Thanks for creating this gem, we at [TRMNL](https://usetrmnl.com) are currently using this gem in production.

While debugging a user reported issue, I noticed that the gem currently doesn't handle birthday events properly (eg: `RRULE:FREQ=YEARLY;BYMONTHDAY=01`) from Fastmail calendar. This PR attempts to fix just that.