### PR TITLE
Upgrade RuboCop from 0.63.1 to 1.85.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
 AllCops:
   TargetRubyVersion: 2.6
   NewCops: disable
+  SuggestExtensions: false
   Exclude:
     - 'gemfiles/**/*'
     - Appraisals

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,6 @@ gem 'appraisal'
 gem 'pry-byebug'
 gem 'rake'
 gem 'rspec'
-gem 'rubocop', '0.63.1'
+gem 'rubocop'
 
 gemspec

--- a/gemfiles/activesupport_7_0.gemfile
+++ b/gemfiles/activesupport_7_0.gemfile
@@ -6,7 +6,7 @@ gem "appraisal"
 gem "pry-byebug"
 gem "rake"
 gem "rspec"
-gem "rubocop", "0.63.1"
+gem "rubocop"
 gem "activesupport", "~> 7.0"
 
 gemspec path: "../"

--- a/gemfiles/activesupport_7_1.gemfile
+++ b/gemfiles/activesupport_7_1.gemfile
@@ -6,7 +6,7 @@ gem "appraisal"
 gem "pry-byebug"
 gem "rake"
 gem "rspec"
-gem "rubocop", "0.63.1"
+gem "rubocop"
 gem "activesupport", "~> 7.1"
 
 gemspec path: "../"

--- a/gemfiles/activesupport_7_2.gemfile
+++ b/gemfiles/activesupport_7_2.gemfile
@@ -6,7 +6,7 @@ gem "appraisal"
 gem "pry-byebug"
 gem "rake"
 gem "rspec"
-gem "rubocop", "0.63.1"
+gem "rubocop"
 gem "activesupport", "~> 7.2"
 
 gemspec path: "../"

--- a/gemfiles/activesupport_8_0.gemfile
+++ b/gemfiles/activesupport_8_0.gemfile
@@ -6,7 +6,7 @@ gem "appraisal"
 gem "pry-byebug"
 gem "rake"
 gem "rspec"
-gem "rubocop", "0.63.1"
+gem "rubocop"
 gem "activesupport", "~> 8.0"
 
 gemspec path: "../"

--- a/lib/rrule/humanizer.rb
+++ b/lib/rrule/humanizer.rb
@@ -120,7 +120,7 @@ module RRule
 
         add list(options.fetch(:bymonth), method(:monthtext), 'and') if bymonth_option
 
-        add list (bymonthday_option.map { |o| nth(o) }), :to_s, 'and' if bymonthday_option
+        add list(bymonthday_option.map { |o| nth(o) }, :to_s, 'and') if bymonthday_option
       end
 
       def weekly
@@ -220,7 +220,7 @@ module RRule
 
       def _bymonthday
         add 'on the'
-        add list (bymonthday_option.map { |o| nth(o) }), :to_s, 'and'
+        add list(bymonthday_option.map { |o| nth(o) }, :to_s, 'and')
       end
 
       def _byhour


### PR DESCRIPTION
RuboCop 0.63.1 is incompatible with Ruby 4.0 because `ostruct` was removed from default gems. Unpin the version and fix the two Style/RedundantParentheses offenses in humanizer.rb.